### PR TITLE
Support for canonical lower-S form signature (Secp256k1)

### DIFF
--- a/src/cosm/crypto/keypairs.py
+++ b/src/cosm/crypto/keypairs.py
@@ -92,14 +92,26 @@ class PrivateKey(PublicKey):
     def private_key_bytes(self) -> bytes:
         return self._private_key_bytes
 
-    def sign(self, message: bytes, deterministic=True, canonicalise: bool = True) -> bytes:
+    def sign(
+        self, message: bytes, deterministic=True, canonicalise: bool = True
+    ) -> bytes:
         sigencode = sigencode_string_canonize if canonicalise else sigencode_string
-        sign_fnc = self._signing_key.sign_deterministic if deterministic else self._signing_key.sign
+        sign_fnc = (
+            self._signing_key.sign_deterministic
+            if deterministic
+            else self._signing_key.sign
+        )
 
         return sign_fnc(message, sigencode=sigencode)
 
-    def sign_digest(self, digest: bytes, deterministic=True, canonicalise: bool = True) -> bytes:
+    def sign_digest(
+        self, digest: bytes, deterministic=True, canonicalise: bool = True
+    ) -> bytes:
         sigencode = sigencode_string_canonize if canonicalise else sigencode_string
-        sign_fnc = self._signing_key.sign_digest_deterministic if deterministic else self._signing_key.sign_digest
+        sign_fnc = (
+            self._signing_key.sign_digest_deterministic
+            if deterministic
+            else self._signing_key.sign_digest
+        )
 
         return sign_fnc(digest, sigencode=sigencode)


### PR DESCRIPTION
Cosmos-SDK considers as valid exclusively the lower-S form of the Secp256k1 signature (so called canonical), upper-S form is rejected as invalid.

This approach is typically used as protection against ECDSA signature "malleability" (tx replay attacks), where `s` coordinate of the existing `(r, s)` signature can be trivially changed to its symmetrical counterpart `-s (mod N)` (**NO** private key is needed), effectively creating new **VALID** signature `(r, -s (mod N))` but obviously with different value.
Thus, **IF** signature(s) is relied upon as something what is solely responsible for bringing the uniqueness in to transaction identifier (tx hash), then swapping `s` coordinate also changes tx hash value, effectively making it brand new transaction as far as blockchain is concerned, hence the mentioned "tx replay attack" term (the new transaction will have the exact same content as the original one, except signature(s)).

Strictly speaking, signature malleability protection is not necessary, since Cosmos-SDK uses account `nonce` to ensure uniqueness of transaction id (tx hash). This means that signature(s) do not play a decisive/primary role in uniqueness of tx hash, though they contribute to tx data which tx hash is calculated from.