### PR TITLE
docs: update docs link & PyPI version shield

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,8 +8,8 @@ labels: ['unconfirmed', 'bug']
 
 Please read and confirm before submitting an issue:
 
-- [ ] I am running the latest CosmPy version.
-- [ ] I checked the [documentation](http://docs.fetch.ai/cosmPy/) and found no answer to my problem.
+- [ ] I am running the latest CosmPy version. [![cosmpy PyPI version](https://img.shields.io/pypi/v/cosmpy?label=cosmpy%20%28PyPI%29)](https://pypi.org/project/cosmpy/)
+- [ ] I checked the [documentation](http://docs.fetch.ai/cosmpy/) and found no answer to my problem.
 - [ ] I checked [here](https://github.com/fetchai/cosmpy/issues) to make sure that this issue has not already been reported.
 
 ## Expected Behavior


### PR DESCRIPTION
### Changes

- adds current PyPI version shield next to version check prompt
- updates docs link to use lower-case (as discussed out-of-band)