### PR TITLE
feat: add oracle example scripts

### DIFF
--- a/examples/aerial_oracle.py
+++ b/examples/aerial_oracle.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2018-2021 Fetch.AI Limited
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+import argparse
+from time import sleep
+
+import requests
+
+from cosmpy.aerial.client import LedgerClient, NetworkConfig
+from cosmpy.aerial.contract import LedgerContract
+from cosmpy.aerial.wallet import LocalWallet
+from cosmpy.crypto.address import Address
+from cosmpy.crypto.keypairs import PrivateKey
+
+COIN_PRICE_URL = (
+    "https://api.coingecko.com/api/v3/simple/price?ids=fetch-ai&vs_currencies=usd"
+)
+UPDATE_INTERVAL_SECONDS = 10
+ORACLE_VALUE_DECIMALS = 5
+
+
+def _parse_commandline():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "contract_path", help="The path to the oracle contract to upload"
+    )
+    parser.add_argument(
+        "contract_address",
+        nargs="?",
+        type=Address,
+        help="The address of the oracle contract if already deployed",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = _parse_commandline()
+
+    wallet = LocalWallet(PrivateKey("T7w1yHq1QIcQiSqV27YSwk+i1i+Y4JMKhkpawCQIh6s="))
+
+    ledger = LedgerClient(NetworkConfig.latest_stable_testnet())
+
+    contract = LedgerContract(args.contract_path, ledger, address=args.contract_address)
+
+    if not args.contract_address:
+        instantiation_message = {"fee": "100"}
+        contract.deploy(instantiation_message, wallet, funds="1atestfet")
+
+    print(f"Oracle contract deployed at: {contract.address}")
+
+    grant_role_message = {"grant_oracle_role": {"address": str(wallet.address())}}
+    contract.execute(grant_role_message, wallet).wait_to_complete()
+
+    print(f"Oracle role granted to address: {str(wallet.address())}")
+
+    while True:
+        resp = requests.get(COIN_PRICE_URL).json()
+        price = resp["fetch-ai"]["usd"]
+        value = int(price * 10**ORACLE_VALUE_DECIMALS)
+
+        update_message = {
+            "update_oracle_value": {
+                "value": str(value),
+                "decimals": str(ORACLE_VALUE_DECIMALS),
+            }
+        }
+        contract.execute(update_message, wallet).wait_to_complete()
+
+        print(f"Oracle value updated to: {price} USD")
+        print(f"Next update in {UPDATE_INTERVAL_SECONDS} seconds...")
+        sleep(UPDATE_INTERVAL_SECONDS)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/aerial_oracle_client.py
+++ b/examples/aerial_oracle_client.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2018-2021 Fetch.AI Limited
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+import argparse
+from time import sleep
+
+from cosmpy.aerial.client import LedgerClient, NetworkConfig
+from cosmpy.aerial.contract import LedgerContract
+from cosmpy.aerial.wallet import LocalWallet
+from cosmpy.crypto.address import Address
+from cosmpy.crypto.keypairs import PrivateKey
+
+REQUEST_INTERVAL_SECONDS = 10
+
+
+def _parse_commandline():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "contract_path", help="The path to the oracle client contract to upload"
+    )
+    parser.add_argument(
+        "oracle_contract_address",
+        type=Address,
+        help="The address of the oracle contract",
+    )
+    parser.add_argument(
+        "contract_address",
+        nargs="?",
+        type=Address,
+        help="The address of the oracle client contract if already deployed",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = _parse_commandline()
+
+    wallet = LocalWallet(PrivateKey("CI5AZQcr+FNl2usnSIQYpXsGWvBxKLRDkieUNIvMOV8="))
+
+    ledger = LedgerClient(NetworkConfig.latest_stable_testnet())
+
+    contract = LedgerContract(args.contract_path, ledger, address=args.contract_address)
+
+    if not args.contract_address:
+        instantiation_message = {
+            "oracle_contract_address": str(args.oracle_contract_address)
+        }
+        contract.deploy(instantiation_message, wallet)
+
+    print(f"Oracle client contract deployed at: {contract.address}")
+
+    while True:
+        request_message = {"query_oracle_value": {}}
+        contract.execute(
+            request_message, wallet, funds="100atestfet"
+        ).wait_to_complete()
+
+        result = contract.query({"oracle_value": {}})
+        print(f"Oracle value successfully retrieved: {result}")
+
+        sleep(REQUEST_INTERVAL_SECONDS)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- adds an example script that deploys and updates an oracle contract with a coin price
- adds another example script that deploys an oracle client contract and requests the oracle value

We still need to decide where to retrieve the oracle and oracle client contract binaries from.