### PR TITLE
feat: add top-up wallet example

### DIFF
--- a/docs/wallet-topup.md
+++ b/docs/wallet-topup.md
@@ -1,0 +1,128 @@
+In a case where you are performing multiple transactions from a certain task_wallet, you can set an algorithm to keep that wallet address topped-up. For this use case, we will use three different wallets: wallet, authz_wallet, and task_wallet. Wallet will be the main wallet address that we don't want to give full access to, therefore we will authorize authz_wallet to send a certain amount of tokens from wallet to task_wallet every time task_wallet balance falls below a certain `minimum_balance` threshold. This way, task_wallet can keep performing transactions using the main wallet's tokens by being topped-up by authz_wallet. Start by defining wallet, authz_wallet and task_wallet address.
+
+```python
+from cosmpy.aerial.wallet import LocalWallet
+from cosmpy.crypto.keypairs import PrivateKey
+from cosmpy.aerial.client import LedgerClient, NetworkConfig
+
+ledger = LedgerClient(NetworkConfig.latest_stable_testnet())
+
+# Define wallets with any private keys
+wallet = LocalWallet(PrivateKey("F7w1yHq1QIcQiSqV27YSwk+i1i+Y4JMKhkpawCQIh6s="))
+
+authz_wallet = LocalWallet(
+    PrivateKey("KI5AZQcr+FNl2usnSIQYpXsGWvBxKLRDkieUNIvMOV8=")
+)
+
+# Define any task_wallet address
+task_wallet_address = 'fetch1ay6grfwhlm00wydwa3nw0x2u44qz4hg2uku8dc'
+```
+Wallet will need to have enough tokens available to top-up task_wallet, and authz_wallet will need enough tokens to pay for transaction fees. Now you will need to give authorization to authz_wallet to send tokens from wallet. You will define the expiration and the spend limit of the authorization in `total_authz_time` and `spend_amount`. The code below shows how to perform this kind of transaction:
+
+```python
+from cosmpy.protos.cosmos.base.v1beta1.coin_pb2 import Coin
+from cosmpy.aerial.client.utils import prepare_and_broadcast_basic_transaction
+from cosmpy.aerial.tx import Transaction
+
+from datetime import datetime, timedelta
+
+from google.protobuf import any_pb2, timestamp_pb2
+from cosmpy.protos.cosmos.authz.v1beta1.authz_pb2 import Grant
+from cosmpy.protos.cosmos.authz.v1beta1.tx_pb2 import MsgGrant
+from cosmpy.protos.cosmos.bank.v1beta1.authz_pb2 import SendAuthorization
+
+# Set total authorization time and spend amount
+total_authz_time = 10000
+amount = 1000000000000000000
+spend_amount = Coin(amount=str(amount), denom="atestfet")
+
+# Authorize authz_wallet to send tokens from wallet
+authz_any = any_pb2.Any()
+authz_any.Pack(
+    SendAuthorization(spend_limit=[spend_amount]),
+    "",
+)
+
+expiry = timestamp_pb2.Timestamp()
+expiry.FromDatetime(datetime.now() + timedelta(seconds=total_authz_time * 60))
+grant = Grant(authorization=authz_any, expiration=expiry)
+
+msg = MsgGrant(
+    granter=str(wallet.address()),
+    grantee=str(authz_wallet.address()),
+    grant=grant,
+)
+
+tx = Transaction()
+tx.add_message(msg)
+
+tx = prepare_and_broadcast_basic_transaction(ledger, tx, wallet)
+tx.wait_to_complete()
+```
+
+Next, you will need to define the amount to top-up, the threshold that will trigger the top-up, and the interval time to query the task_wallet balance. We will define these amounts in the following variables: `top_up_amount`, `minimum_balance` and `interval_time`.
+
+```python
+
+# Top-up amount
+amount = 10000000000000000
+top_up_amount = Coin(amount=str(amount), denom="atestfet")
+
+# Minimum balance for task_wallet
+minimum_balance = 1000000000000000
+
+# Interval to query task_wallet's balance in seconds
+interval_time = 5
+```
+
+Finally, run a continuously running loop that will:
+* Check the main wallet's balance to make sure it has enough tokens to top-up the task_wallet_address
+* Check task_wallet's balance, if it is lower than `minimum_balance` then authz_wallet will send `top_up_amount` of tokens from wallet to task_wallet
+* Sleep `interval_time` and repeat
+
+```python
+import time
+from cosmpy.protos.cosmos.authz.v1beta1.tx_pb2 import MsgExec
+from cosmpy.protos.cosmos.bank.v1beta1.tx_pb2 import MsgSend
+
+while True:
+
+    wallet_address = str(wallet.address())
+
+    wallet_balance = ledger.query_bank_balance(wallet_address)
+
+    if wallet_balance < amount:
+        print("Wallet doesn't have enough balance to top-up task_wallet")
+        break
+
+    task_wallet_balance = ledger.query_bank_balance(task_wallet_address)
+
+    if task_wallet_balance < minimum_balance:
+
+        print("topping up task wallet")
+        # Top-up task_wallet
+        msg = any_pb2.Any()
+        msg.Pack(
+            MsgSend(
+                from_address=wallet_address,
+                to_address=task_wallet_address,
+                amount=[top_up_amount],
+            ),
+            "",
+        )
+
+        tx = Transaction()
+        tx.add_message(MsgExec(grantee=str(authz_wallet.address()), msgs=[msg]))
+
+        tx = prepare_and_broadcast_basic_transaction(ledger, tx, authz_wallet)
+        tx.wait_to_complete()
+
+    time.sleep(interval_time)
+```
+
+While the code above keeps running, you can make sure that task_wallet is always topped-up as long as authz_wallet has authorization to send the required tokens and the main wallet has enough balance.
+
+You can also check out the authorization and top-up code examples at [`authz`](https://github.com/fetchai/cosmpy/blob/develop/examples/aerial_authz.py) and [`top-up`](https://github.com/fetchai/cosmpy/blob/develop/examples/aerial_topup.py) respectively.
+
+
+

--- a/examples/aerial_authz.py
+++ b/examples/aerial_authz.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2018-2021 Fetch.AI Limited
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+from datetime import datetime, timedelta
+
+from google.protobuf import any_pb2, timestamp_pb2
+
+from cosmpy.aerial.client import LedgerClient, NetworkConfig
+from cosmpy.aerial.client.utils import prepare_and_broadcast_basic_transaction
+from cosmpy.aerial.tx import Transaction
+from cosmpy.aerial.wallet import LocalWallet
+from cosmpy.crypto.keypairs import PrivateKey
+from cosmpy.protos.cosmos.authz.v1beta1.authz_pb2 import GenericAuthorization, Grant
+from cosmpy.protos.cosmos.authz.v1beta1.tx_pb2 import MsgGrant
+
+
+def main():
+
+    wallet = LocalWallet(PrivateKey("F7w1yHq1QIcQiSqV27YSwk+i1i+Y4JMKhkpawCQIh6s="))
+
+    # Set authz_wallet that will be granted authorization to send tokens from wallet
+    authz_wallet = LocalWallet(
+        PrivateKey("KI5AZQcr+FNl2usnSIQYpXsGWvBxKLRDkieUNIvMOV8=")
+    )
+
+    ledger = LedgerClient(NetworkConfig.latest_stable_testnet())
+
+    # Set authorization time for authz_wallet in minutes
+    total_authz_time = 1000
+
+    # Authorize authz_wallet to send tokens from wallet
+    authz_any = any_pb2.Any()
+    authz_any.Pack(
+        GenericAuthorization(msg="/cosmos.bank.v1beta1.MsgSend"),
+        "",
+    )
+
+    expiry = timestamp_pb2.Timestamp()
+    expiry.FromDatetime(datetime.now() + timedelta(seconds=total_authz_time * 60))
+    grant = Grant(authorization=authz_any, expiration=expiry)
+
+    msg = MsgGrant(
+        granter=str(wallet.address()),
+        grantee=str(authz_wallet.address()),
+        grant=grant,
+    )
+
+    tx = Transaction()
+    tx.add_message(msg)
+
+    tx = prepare_and_broadcast_basic_transaction(ledger, tx, wallet)
+    tx.wait_to_complete()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/aerial_authz.py
+++ b/examples/aerial_authz.py
@@ -49,7 +49,7 @@ def _parse_commandline():
         "spend_limit",
         type=int,
         nargs="?",
-        default=10000000000000000,
+        default=1000000000000000000,
         help="maximum tokens that authz_wallet will be able to spend from wallet",
     )
 

--- a/examples/aerial_authz.py
+++ b/examples/aerial_authz.py
@@ -16,6 +16,7 @@
 #   limitations under the License.
 #
 # ------------------------------------------------------------------------------
+import argparse
 from datetime import datetime, timedelta
 
 from google.protobuf import any_pb2, timestamp_pb2
@@ -29,21 +30,33 @@ from cosmpy.protos.cosmos.authz.v1beta1.authz_pb2 import GenericAuthorization, G
 from cosmpy.protos.cosmos.authz.v1beta1.tx_pb2 import MsgGrant
 
 
+def _parse_commandline():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "authz_address",
+        help="address that will be granted authorization to send tokens from wallet",
+    )
+    parser.add_argument(
+        "total_authz_time",
+        type=int,
+        help="authorization time for authz_address in minutes",
+    )
+
+    return parser.parse_args()
+
+
 def main():
+    args = _parse_commandline()
 
     wallet = LocalWallet(PrivateKey("F7w1yHq1QIcQiSqV27YSwk+i1i+Y4JMKhkpawCQIh6s="))
 
-    # Set authz_wallet that will be granted authorization to send tokens from wallet
-    authz_wallet = LocalWallet(
-        PrivateKey("KI5AZQcr+FNl2usnSIQYpXsGWvBxKLRDkieUNIvMOV8=")
-    )
+    authz_address = args.authz_address
 
     ledger = LedgerClient(NetworkConfig.latest_stable_testnet())
 
-    # Set authorization time for authz_wallet in minutes
-    total_authz_time = 1000
+    total_authz_time = args.total_authz_time
 
-    # Authorize authz_wallet to send tokens from wallet
+    # Authorize authz_address to send tokens from wallet
     authz_any = any_pb2.Any()
     authz_any.Pack(
         GenericAuthorization(msg="/cosmos.bank.v1beta1.MsgSend"),
@@ -56,7 +69,7 @@ def main():
 
     msg = MsgGrant(
         granter=str(wallet.address()),
-        grantee=str(authz_wallet.address()),
+        grantee=authz_address,
         grant=grant,
     )
 

--- a/examples/aerial_authz.py
+++ b/examples/aerial_authz.py
@@ -39,6 +39,8 @@ def _parse_commandline():
     parser.add_argument(
         "total_authz_time",
         type=int,
+        nargs="?",
+        default=10,
         help="authorization time for authz_address in minutes",
     )
 

--- a/examples/aerial_authz.py
+++ b/examples/aerial_authz.py
@@ -26,8 +26,10 @@ from cosmpy.aerial.client.utils import prepare_and_broadcast_basic_transaction
 from cosmpy.aerial.tx import Transaction
 from cosmpy.aerial.wallet import LocalWallet
 from cosmpy.crypto.keypairs import PrivateKey
-from cosmpy.protos.cosmos.authz.v1beta1.authz_pb2 import GenericAuthorization, Grant
+from cosmpy.protos.cosmos.authz.v1beta1.authz_pb2 import Grant
 from cosmpy.protos.cosmos.authz.v1beta1.tx_pb2 import MsgGrant
+from cosmpy.protos.cosmos.bank.v1beta1.authz_pb2 import SendAuthorization
+from cosmpy.protos.cosmos.base.v1beta1.coin_pb2 import Coin
 
 
 def _parse_commandline():
@@ -42,6 +44,13 @@ def _parse_commandline():
         nargs="?",
         default=10,
         help="authorization time for authz_address in minutes",
+    )
+    parser.add_argument(
+        "spend_limit",
+        type=int,
+        nargs="?",
+        default=10000000000000000,
+        help="maximum tokens that authz_wallet will be able to spend from wallet",
     )
 
     return parser.parse_args()
@@ -58,10 +67,14 @@ def main():
 
     total_authz_time = args.total_authz_time
 
-    # Authorize authz_address to send tokens from wallet
+    amount = args.spend_limit
+
+    spend_amount = Coin(amount=str(amount), denom="atestfet")
+
+    # Authorize authz_wallet to send tokens from wallet
     authz_any = any_pb2.Any()
     authz_any.Pack(
-        GenericAuthorization(msg="/cosmos.bank.v1beta1.MsgSend"),
+        SendAuthorization(spend_limit=[spend_amount]),
         "",
     )
 

--- a/examples/aerial_topup.py
+++ b/examples/aerial_topup.py
@@ -17,89 +17,57 @@
 #
 # ------------------------------------------------------------------------------
 import time
-from datetime import datetime, timedelta
 
-from google.protobuf import any_pb2, timestamp_pb2
+from google.protobuf import any_pb2
 
 from cosmpy.aerial.client import LedgerClient, NetworkConfig
 from cosmpy.aerial.client.utils import prepare_and_broadcast_basic_transaction
 from cosmpy.aerial.tx import Transaction
 from cosmpy.aerial.wallet import LocalWallet
 from cosmpy.crypto.keypairs import PrivateKey
-from cosmpy.protos.cosmos.authz.v1beta1.authz_pb2 import GenericAuthorization, Grant
-from cosmpy.protos.cosmos.authz.v1beta1.tx_pb2 import MsgExec, MsgGrant
+from cosmpy.protos.cosmos.authz.v1beta1.tx_pb2 import MsgExec
 from cosmpy.protos.cosmos.bank.v1beta1.tx_pb2 import MsgSend
 from cosmpy.protos.cosmos.base.v1beta1.coin_pb2 import Coin
 
 
 def main():
 
-    # Set main wallet
     wallet = LocalWallet(PrivateKey("F7w1yHq1QIcQiSqV27YSwk+i1i+Y4JMKhkpawCQIh6s="))
-
-    # Set task wallet [will perform transactions]
     task_wallet = LocalWallet(
         PrivateKey("HI5AZQcr+FNl2usnSIQYpXsGWvBxKLRDkieUNIvMOV8=")
     )
 
-    # Set authz wallet [will top-up task_wallet from wallet]
+    # authz_wallet must have authorization to send tokens from wallet. see aerial_authz.py
     authz_wallet = LocalWallet(
         PrivateKey("KI5AZQcr+FNl2usnSIQYpXsGWvBxKLRDkieUNIvMOV8=")
     )
 
     ledger = LedgerClient(NetworkConfig.latest_stable_testnet())
 
-    # Set authorization time for authz_wallet in minutes
-    total_authz_time = 1000
-
-    # Authorize authz_wallet to send tokens from wallet
-    authz_any = any_pb2.Any()
-    authz_any.Pack(
-        GenericAuthorization(msg="/cosmos.bank.v1beta1.MsgSend"),
-        "",
-    )
-
-    expiry = timestamp_pb2.Timestamp()
-    expiry.FromDatetime(datetime.now() + timedelta(seconds=total_authz_time * 60))
-    grant = Grant(authorization=authz_any, expiration=expiry)
-
-    msg = MsgGrant(
-        granter=str(wallet.address()),
-        grantee=str(authz_wallet.address()),
-        grant=grant,
-    )
-
-    tx = Transaction()
-    tx.add_message(msg)
-
-    tx = prepare_and_broadcast_basic_transaction(ledger, tx, wallet)
-    tx.wait_to_complete()
-
     # Set top-up amount
     amount = 10000000000000000
     top_up_amount = Coin(amount=str(amount), denom="atestfet")
 
-    # Choose any validator
-    validators = ledger.query_validators()
-    validator = validators[0]
-
     # Set minimum balance for task_wallet
     minimum_balance = 1000000000000000
+
+    # Set interval to query task_wallet's balance
+    interval_time = 5
 
     while True:
 
         wallet_balance = ledger.query_bank_balance(str(wallet.address()))
 
         if wallet_balance < amount:
-            print("Wallet doesnt have enough balance to top-up task_wallet")
+            print("Wallet doesnt have enought balance to top-up task_wallet")
             break
 
         task_wallet_balance = ledger.query_bank_balance(str(task_wallet.address()))
 
         if task_wallet_balance < minimum_balance:
 
-            # Top-up task_wallet
             print("topping up task wallet")
+            # Top-up task_wallet
             msg = any_pb2.Any()
             msg.Pack(
                 MsgSend(
@@ -116,12 +84,7 @@ def main():
             tx = prepare_and_broadcast_basic_transaction(ledger, tx, authz_wallet)
             tx.wait_to_complete()
 
-        # Perform delegation transactions from task_wallet to deplete its balance
-        print("task_wallet > performing transaction: delegating tokens")
-        tx = ledger.delegate_tokens(validator.address, 100, task_wallet)
-        tx.wait_to_complete()
-
-        time.sleep(5)
+        time.sleep(interval_time)
 
 
 if __name__ == "__main__":

--- a/examples/aerial_topup.py
+++ b/examples/aerial_topup.py
@@ -40,16 +40,22 @@ def _parse_commandline():
     parser.add_argument(
         "top_up_amount",
         type=int,
+        nargs="?",
+        default=10000000000000000,
         help="top-up amount from wallet address to task_wallet address",
     )
     parser.add_argument(
         "minimum_balance",
         type=int,
+        nargs="?",
+        default=1000000000000000,
         help="minimum task_wallet address balance that will trigger top-up",
     )
     parser.add_argument(
         "interval_time",
         type=int,
+        nargs="?",
+        default=5,
         help="interval time in seconds to query task_wallet's balance",
     )
 

--- a/examples/aerial_topup.py
+++ b/examples/aerial_topup.py
@@ -91,7 +91,7 @@ def main():
         wallet_balance = ledger.query_bank_balance(wallet_address)
 
         if wallet_balance < amount:
-            print("Wallet doesnt have enought balance to top-up task_wallet")
+            print("Wallet doesn't have enough balance to top-up task_wallet")
             break
 
         task_wallet_balance = ledger.query_bank_balance(task_wallet_address)

--- a/examples/aerial_wallet_top_up.py
+++ b/examples/aerial_wallet_top_up.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2018-2021 Fetch.AI Limited
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+import time
+from datetime import datetime, timedelta
+
+from google.protobuf import any_pb2, timestamp_pb2
+
+from cosmpy.aerial.client import LedgerClient, NetworkConfig
+from cosmpy.aerial.client.utils import prepare_and_broadcast_basic_transaction
+from cosmpy.aerial.tx import Transaction
+from cosmpy.aerial.wallet import LocalWallet
+from cosmpy.crypto.keypairs import PrivateKey
+from cosmpy.protos.cosmos.authz.v1beta1.authz_pb2 import GenericAuthorization, Grant
+from cosmpy.protos.cosmos.authz.v1beta1.tx_pb2 import MsgExec, MsgGrant
+from cosmpy.protos.cosmos.bank.v1beta1.tx_pb2 import MsgSend
+from cosmpy.protos.cosmos.base.v1beta1.coin_pb2 import Coin
+
+
+def main():
+
+    # Set main wallet
+    wallet = LocalWallet(PrivateKey("F7w1yHq1QIcQiSqV27YSwk+i1i+Y4JMKhkpawCQIh6s="))
+
+    # Set task wallet [will perform transactions]
+    task_wallet = LocalWallet(
+        PrivateKey("HI5AZQcr+FNl2usnSIQYpXsGWvBxKLRDkieUNIvMOV8=")
+    )
+
+    # Set authz wallet [will top-up task_wallet from wallet]
+    authz_wallet = LocalWallet(
+        PrivateKey("KI5AZQcr+FNl2usnSIQYpXsGWvBxKLRDkieUNIvMOV8=")
+    )
+
+    ledger = LedgerClient(NetworkConfig.latest_stable_testnet())
+
+    # Set authorization time for authz_wallet in minutes
+    total_authz_time = 1000
+
+    # Authorize authz_wallet to send tokens from wallet
+    authz_any = any_pb2.Any()
+    authz_any.Pack(
+        GenericAuthorization(msg="/cosmos.bank.v1beta1.MsgSend"),
+        "",
+    )
+
+    expiry = timestamp_pb2.Timestamp()
+    expiry.FromDatetime(datetime.now() + timedelta(seconds=total_authz_time * 60))
+    grant = Grant(authorization=authz_any, expiration=expiry)
+
+    msg = MsgGrant(
+        granter=str(wallet.address()),
+        grantee=str(authz_wallet.address()),
+        grant=grant,
+    )
+
+    tx = Transaction()
+    tx.add_message(msg)
+
+    tx = prepare_and_broadcast_basic_transaction(ledger, tx, wallet)
+    tx.wait_to_complete()
+
+    # Set top-up amount
+    amount = 10000000000000000
+    top_up_amount = Coin(amount=str(amount), denom="atestfet")
+
+    # Choose any validator
+    validators = ledger.query_validators()
+    validator = validators[0]
+
+    # Set minimum balance for task_wallet
+    minimum_balance = 1000000000000000
+
+    while True:
+
+        wallet_balance = ledger.query_bank_balance(str(wallet.address()))
+
+        if wallet_balance < amount:
+            print("Wallet doesnt have enough balance to top-up task_wallet")
+            break
+
+        task_wallet_balance = ledger.query_bank_balance(str(task_wallet.address()))
+
+        if task_wallet_balance < minimum_balance:
+
+            # Top-up task_wallet
+            print("topping up task wallet")
+            msg = any_pb2.Any()
+            msg.Pack(
+                MsgSend(
+                    from_address=str(wallet.address()),
+                    to_address=str(task_wallet.address()),
+                    amount=[top_up_amount],
+                ),
+                "",
+            )
+
+            tx = Transaction()
+            tx.add_message(MsgExec(grantee=str(authz_wallet.address()), msgs=[msg]))
+
+            tx = prepare_and_broadcast_basic_transaction(ledger, tx, authz_wallet)
+            tx.wait_to_complete()
+
+        # Perform delegation transactions from task_wallet to deplete its balance
+        print("task_wallet > performing transaction: delegating tokens")
+        tx = ledger.delegate_tokens(validator.address, 100, task_wallet)
+        tx.wait_to_complete()
+
+        time.sleep(5)
+
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,7 @@ nav:
     - Stake Auto-Compounder: 'auto-compounder.md'
     - Stake Optimizer: 'stake-optimizer.md'
     - Oracles: 'oracles.md'
+    - Wallet Top-up: 'wallet-topup.md'
 
 theme:
   name: material


### PR DESCRIPTION
Used 3 wallets for this example:
* wallet: the main wallet that has a certain balance but the user doesn't want to perform transactions with it
* task_wallet: will be used to perform transactions using the main wallet's tokens
* authz_wallt: will be authorized to send tokens from wallet to task_wallet when task_wallet balance falls below a threshold