### PR TITLE
fix: ignored prefix when creating Address from another

### DIFF
--- a/cosmpy/crypto/address.py
+++ b/cosmpy/crypto/address.py
@@ -78,7 +78,8 @@ class Address:
 
         elif isinstance(value, Address):
             self._address = value._address
-            self._display = value._display
+            # prefix might be different from the original Address so we need to reencode it here.
+            self._display = _to_bech32(prefix, self._address)
         else:
             raise TypeError("Unexpected type of `value` parameter")  # pragma: no cover
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_url: https://docs.fetch.ai/cosmpy
 site_description: Everything you need to know about CosmPy.
 repo_url: https://github.com/fetchai/cosmpy
 edit_uri: ""
-site_author: developer@fetch.a
+site_author: developer@fetch.ai
 
 nav:
   - Getting started: 'index.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_url: https://docs.fetch.ai/cosmpy
 site_description: Everything you need to know about CosmPy.
 repo_url: https://github.com/fetchai/cosmpy
 edit_uri: ""
-site_author: developer@fetch.ai
+site_author: developer@fetch.a
 
 nav:
   - Getting started: 'index.md'

--- a/tests/unit/test_crypto/test_address.py
+++ b/tests/unit/test_crypto/test_address.py
@@ -77,4 +77,6 @@ class AddressTestCase(unittest.TestCase):
         """Test create an Address from another but with a custom prefix."""
         address = Address("fetch12hyw0z8za0sc9wwfhkdz2qrc89a87z42py23vn")
         val_address = Address(address, prefix="fetchvaloper")
-        self.assertEqual(str(val_address), "fetchvaloper12hyw0z8za0sc9wwfhkdz2qrc89a87z42yq4jl5")
+        self.assertEqual(
+            str(val_address), "fetchvaloper12hyw0z8za0sc9wwfhkdz2qrc89a87z42yq4jl5"
+        )

--- a/tests/unit/test_crypto/test_address.py
+++ b/tests/unit/test_crypto/test_address.py
@@ -72,3 +72,9 @@ class AddressTestCase(unittest.TestCase):
         """Test create Address from str with negative result."""
         with self.assertRaises(RuntimeError):
             Address("certainly not an address")
+
+    def test_address_from_address_with_custom_prefix(self):
+        """Test create an Address from another but with a custom prefix."""
+        address = Address("fetch12hyw0z8za0sc9wwfhkdz2qrc89a87z42py23vn")
+        val_address = Address(address, prefix="fetchvaloper")
+        self.assertEqual(str(val_address), "fetchvaloper12hyw0z8za0sc9wwfhkdz2qrc89a87z42yq4jl5")


### PR DESCRIPTION
When an `Address` object is used to create another `Address`, the
prefix argument is ignored and thus the original `Address` is displayed.

This fix simply reencode the new `Address` when constructed.
