### PR TITLE
feat: add pagination to TotalSupply

### DIFF
--- a/cosmpy/bank/rest_client.py
+++ b/cosmpy/bank/rest_client.py
@@ -90,7 +90,7 @@ class BankRestClient(Bank):
 
         :return: QueryTotalSupplyResponse
         """
-        response = self._rest_api.get(f"{self.API_URL}/supply")
+        response = self._rest_api.get(f"{self.API_URL}/supply", request)
         return Parse(response, QueryTotalSupplyResponse())
 
     def SupplyOf(self, request: QuerySupplyOfRequest) -> QuerySupplyOfResponse:


### PR DESCRIPTION
When query for all the denoms available on the chain, we can use a pagination.
note: pagination using pagination key does not work. need to use offset and limits