### PR TITLE
Fix error in REST Client: Can not find message descriptor by type_url…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,7 +243,7 @@ new_env_dev: clean
 lint:
 	black $(PYCOSM_SRC_DIR) $(PYCOSM_TESTS_DIR) $(PYCOSM_EXAMPLES_DIR) setup.py --exclude $(OUTPUT_FOLDER)
 	isort $(PYCOSM_SRC_DIR) $(PYCOSM_TESTS_DIR) $(PYCOSM_EXAMPLES_DIR) setup.py
-	flake8 $(PYCOSM_SRC_DIR) $(PYCOSM_TESTS_DIR) $(PYCOSM_EXAMPLES_DIR) setup.py
+	flake8 $(PYCOSM_SRC_DIR) $(PYCOSM_TESTS_DIR) $(PYCOSM_EXAMPLES_DIR) setup.py --per-file-ignores="__init__.py:F401" 
 	vulture $(PYCOSM_SRC_DIR) $(PYCOSM_TESTS_DIR) $(PYCOSM_EXAMPLES_DIR) setup.py --exclude '*_pb2.py,*_pb2_grpc.py' --min-confidence 100
 
 .PHONY: security

--- a/cosmpy/aerial/client/__init__.py
+++ b/cosmpy/aerial/client/__init__.py
@@ -56,6 +56,7 @@ from cosmpy.protos.cosmos.bank.v1beta1.query_pb2 import (
     QueryBalanceRequest,
 )
 from cosmpy.protos.cosmos.bank.v1beta1.query_pb2_grpc import QueryStub as BankGrpcClient
+from cosmpy.protos.cosmos.crypto.ed25519.keys_pb2 import PubKey
 from cosmpy.protos.cosmos.distribution.v1beta1.query_pb2 import (
     QueryDelegationRewardsRequest,
 )
@@ -71,7 +72,6 @@ from cosmpy.protos.cosmos.staking.v1beta1.query_pb2 import (
     QueryDelegatorUnbondingDelegationsRequest,
     QueryValidatorsRequest,
 )
-from cosmpy.protos.cosmos.crypto.ed25519.keys_pb2 import PubKey
 from cosmpy.protos.cosmos.staking.v1beta1.query_pb2_grpc import (
     QueryStub as StakingGrpcClient,
 )

--- a/cosmpy/aerial/client/__init__.py
+++ b/cosmpy/aerial/client/__init__.py
@@ -71,6 +71,7 @@ from cosmpy.protos.cosmos.staking.v1beta1.query_pb2 import (
     QueryDelegatorUnbondingDelegationsRequest,
     QueryValidatorsRequest,
 )
+from cosmpy.protos.cosmos.crypto.ed25519.keys_pb2 import PubKey
 from cosmpy.protos.cosmos.staking.v1beta1.query_pb2_grpc import (
     QueryStub as StakingGrpcClient,
 )

--- a/cosmpy/bank/rest_client.py
+++ b/cosmpy/bank/rest_client.py
@@ -90,7 +90,7 @@ class BankRestClient(Bank):
 
         :return: QueryTotalSupplyResponse
         """
-        response = self._rest_api.get(f"{self.API_URL}/supply")
+        response = self._rest_api.get(f"{self.API_URL}/supply", request)
         return Parse(response, QueryTotalSupplyResponse())
 
     def SupplyOf(self, request: QuerySupplyOfRequest) -> QuerySupplyOfResponse:


### PR DESCRIPTION
I described this error in the bug report: [https://github.com/fetchai/cosmpy/issues/284](https://github.com/fetchai/cosmpy/issues/284)
This little pull request solves the problem.