### PR TITLE
Fixed floating gas_price problem

### DIFF
--- a/cosmpy/aerial/client/__init__.py
+++ b/cosmpy/aerial/client/__init__.py
@@ -421,7 +421,8 @@ class LedgerClient:
         return self._gas_strategy.estimate_gas(tx)
 
     def estimate_fee_from_gas(self, gas_limit: int) -> str:
-        return f"{gas_limit * self.network_config.fee_minimum_gas_price}{self.network_config.fee_denomination}"
+        fee = int(-(-(gas_limit * self.network_config.fee_minimum_gas_price) // 1))
+        return f"{fee}{self.network_config.fee_denomination}"
 
     def estimate_gas_and_fee_for_tx(self, tx: Transaction) -> Tuple[int, str]:
         gas_estimate = self.estimate_gas_for_tx(tx)


### PR DESCRIPTION
For some chains like [Juno](https://github.com/cosmos/chain-registry/blob/master/testnets/junotestnet/chain.json) have less-than-1 
 average gas price (0.04 factor) but older function cannot set to that price
 
 ```
 juno_testnet = NetworkConfig(
            chain_id="uni-5",
            url="grpc+http://juno-testnet-grpc.polkachu.com:12690",
            fee_minimum_gas_price=0.03,
            fee_denomination="ujunox",
            staking_denomination="ujunox",
        )
 ```



