### PR TITLE
Fixed bug where a float within a string could not be cast directly to an int

### DIFF
--- a/cosmpy/aerial/client/__init__.py
+++ b/cosmpy/aerial/client/__init__.py
@@ -393,7 +393,7 @@ class LedgerClient:
                 for reward in rewards_resp.rewards:
                     if reward.denom == self.network_config.staking_denomination:
                         stake_reward = (
-                            int(reward.amount) // COSMOS_SDK_DEC_COIN_PRECISION
+                            int(float(reward.amount)) // COSMOS_SDK_DEC_COIN_PRECISION
                         )
                         break
 


### PR DESCRIPTION
It is possible for a `QueryDelegatorDelegationsRequest` to return staking rewards that have sub-integer precision. When these accounts have such rewards available, a call to `query_staking_summary()` will produce an unhandled `ValueError` exception when trying to cast the `1.234` value as an `int()` on line 396.

```ValueError: invalid literal for int() with base 10: 1.234```

This commit replaces the `int(reward.amount)` cast with a `int(float(reward.amount))` double-cast so that any decimal values present in `reward.amount` are properly converted to a `float` _first_ before being converted to an `int` second.

This prevents the unhandled `ValueError` exception when a float is being converted to an `int` directly.

See https://stackoverflow.com/questions/1841565/valueerror-invalid-literal-for-int-with-base-10 for more details.