### PR TITLE
fix: move warning from docs to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ A python library for interacting with cosmos based blockchain networks
   </a>
 </p>
 
+> We recently stopped using the `develop` branch for feature consolidation and renamed `master` to `main`. Please see the [Contribution Guides][contributing] for up-to-date instructions.
+
 ## To Install
 
 ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,8 +6,6 @@ CosmPy is a Python library for interacting with Cosmos-based blockchain networks
 * Easy interface for deploying and interacting with Cosmwasm smart contracts.
 * Access to low-level ledger APIs for advanced use-cases.
 
-> We recently stopped using the `develop` branch for feature consolidation and renamed `master` to `main`. Please see the [Contribution Guides][contributing] for up-to-date instructions. 
-
 ## To install
 
 Ensure you have Python (version `3.8`, `3.9` or `3.10`):


### PR DESCRIPTION
## Proposed changes

This move warning about workflow changes from docs --> index to readme.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to stop working as expected)
- [x] Something else (e.g. tests, scripts, example, deployment, infrastructure, ...)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/fetchai/cosmpy/blob/main/CONTRIBUTING.md) document.
- [x] I have based my branch, and I am making a pull request against, the `main` branch.
- [x] Checks and tests pass locally.

### If applicable

- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have checked that code coverage does not decrease.
- [x] I have added/updated the documentations.