### PR TITLE
Add metadata attribute to REST

### DIFF
--- a/cosmpy/auth/interface.py
+++ b/cosmpy/auth/interface.py
@@ -20,6 +20,7 @@
 """Interface for the Auth functionality of CosmosSDK."""
 
 from abc import ABC, abstractmethod
+from typing import Optional, Tuple
 
 from cosmpy.protos.cosmos.auth.v1beta1.query_pb2 import (
     QueryAccountRequest,
@@ -33,21 +34,31 @@ class Auth(ABC):
     """Auth abstract class."""
 
     @abstractmethod
-    def Account(self, request: QueryAccountRequest) -> QueryAccountResponse:
+    def Account(
+        self,
+        request: QueryAccountRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryAccountResponse:
         """
         Query account data - sequence, account_id, etc.
 
         :param request: QueryAccountRequest that contains account address
+        :param metadata: The metadata for the call or None. metadata are additional headers
 
         :return: QueryAccountResponse
         """
 
     @abstractmethod
-    def Params(self, request: QueryParamsRequest) -> QueryParamsResponse:
+    def Params(
+        self,
+        request: QueryParamsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryParamsResponse:
         """
         Query all parameters.
 
         :param request: QueryParamsRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers        :param metadata: The metadata for the call or None. metadata are additional headers
 
         :return: QueryParamsResponse
         """

--- a/cosmpy/auth/rest_client.py
+++ b/cosmpy/auth/rest_client.py
@@ -18,6 +18,7 @@
 # ------------------------------------------------------------------------------
 
 """Implementation of Auth interface using REST."""
+from typing import Optional, Tuple
 
 from google.protobuf.json_format import Parse
 
@@ -44,23 +45,33 @@ class AuthRestClient(Auth):
         """
         self._rest_api = rest_api
 
-    def Account(self, request: QueryAccountRequest) -> QueryAccountResponse:
+    def Account(
+        self,
+        request: QueryAccountRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryAccountResponse:
         """
         Query account data - sequence, account_id, etc.
 
         :param request: QueryAccountRequest that contains account address
+        :param metadata: The metadata for the call or None. metadata are additional headers
+        :param metadata: The metadata for the call or None. metadata are additional headers
 
         :return: QueryAccountResponse
         """
         json_response = self._rest_api.get(f"{self.API_URL}/accounts/{request.address}")
         return Parse(json_response, QueryAccountResponse())
 
-    def Params(self, request: QueryParamsRequest) -> QueryParamsResponse:
+    def Params(
+        self,
+        request: QueryParamsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryParamsResponse:
         """
         Query all parameters.
 
         :param request: QueryParamsRequest
-
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryParamsResponse
         """
         json_response = self._rest_api.get(f"{self.API_URL}/params")

--- a/cosmpy/bank/interface.py
+++ b/cosmpy/bank/interface.py
@@ -20,6 +20,7 @@
 """Interface for the Bank functionality of CosmosSDK."""
 
 from abc import ABC, abstractmethod
+from typing import Optional, Tuple
 
 from cosmpy.protos.cosmos.bank.v1beta1.query_pb2 import (
     QueryAllBalancesRequest,
@@ -43,75 +44,106 @@ class Bank(ABC):
     """Bank abstract class."""
 
     @abstractmethod
-    def Balance(self, request: QueryBalanceRequest) -> QueryBalanceResponse:
+    def Balance(
+        self,
+        request: QueryBalanceRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryBalanceResponse:
         """
         Query balance of selected denomination from specific account.
 
         :param request: QueryBalanceRequest with address and denomination
+        :param metadata: The metadata for the call or None. metadata are additional headers
 
         :return: QueryBalanceResponse
         """
 
     @abstractmethod
-    def AllBalances(self, request: QueryAllBalancesRequest) -> QueryAllBalancesResponse:
+    def AllBalances(
+        self,
+        request: QueryAllBalancesRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryAllBalancesResponse:
         """
         Query balance of all denominations from specific account.
 
         :param request: QueryAllBalancesRequest with account address
+        :param metadata: The metadata for the call or None. metadata are additional headers
 
         :return: QueryAllBalancesResponse
         """
 
     @abstractmethod
-    def TotalSupply(self, request: QueryTotalSupplyRequest) -> QueryTotalSupplyResponse:
+    def TotalSupply(
+        self,
+        request: QueryTotalSupplyRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryTotalSupplyResponse:
         """
         Query total supply of all denominations.
 
         :param request: QueryTotalSupplyRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
 
         :return: QueryTotalSupplyResponse
         """
 
     @abstractmethod
-    def SupplyOf(self, request: QuerySupplyOfRequest) -> QuerySupplyOfResponse:
+    def SupplyOf(
+        self,
+        request: QuerySupplyOfRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QuerySupplyOfResponse:
         """
         Query total supply of specific denomination.
 
         :param request: QuerySupplyOfRequest with denomination
+        :param metadata: The metadata for the call or None. metadata are additional headers
 
         :return: QuerySupplyOfResponse
         """
 
     @abstractmethod
-    def Params(self, request: QueryParamsRequest) -> QueryParamsResponse:
+    def Params(
+        self,
+        request: QueryParamsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryParamsResponse:
         """
         Query the parameters of bank module.
 
         :param request: QueryParamsRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
 
         :return: QueryParamsResponse
         """
 
     @abstractmethod
     def DenomMetadata(
-        self, request: QueryDenomMetadataRequest
+        self,
+        request: QueryDenomMetadataRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryDenomMetadataResponse:
         """
         Query the client metadata for all registered coin denominations.
 
         :param request: QueryDenomMetadataRequest with denomination
+        :param metadata: The metadata for the call or None. metadata are additional headers
 
         :return: QueryDenomMetadataResponse
         """
 
     @abstractmethod
     def DenomsMetadata(
-        self, request: QueryDenomsMetadataRequest
+        self,
+        request: QueryDenomsMetadataRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryDenomsMetadataResponse:
         """
         Query the client metadata of a given coin denomination.
 
         :param request: QueryDenomsMetadataRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
 
         :return: QueryDenomsMetadataResponse
         """

--- a/cosmpy/bank/rest_client.py
+++ b/cosmpy/bank/rest_client.py
@@ -18,6 +18,7 @@
 # ------------------------------------------------------------------------------
 
 """Implementation of Bank interface using REST."""
+from typing import Optional, Tuple
 
 from google.protobuf.json_format import Parse
 
@@ -54,11 +55,16 @@ class BankRestClient(Bank):
         """
         self._rest_api = rest_api
 
-    def Balance(self, request: QueryBalanceRequest) -> QueryBalanceResponse:
+    def Balance(
+        self,
+        request: QueryBalanceRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryBalanceResponse:
         """
         Query balance of selected denomination from specific account.
 
         :param request: QueryBalanceRequest with address and denomination
+        :param metadata: The metadata for the call or None. metadata are additional headers
 
         :return: QueryBalanceResponse
         """
@@ -69,11 +75,16 @@ class BankRestClient(Bank):
         )
         return Parse(response, QueryBalanceResponse())
 
-    def AllBalances(self, request: QueryAllBalancesRequest) -> QueryAllBalancesResponse:
+    def AllBalances(
+        self,
+        request: QueryAllBalancesRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryAllBalancesResponse:
         """
         Query balance of all denominations from specific account.
 
         :param request: QueryAllBalancesRequest with account address
+        :param metadata: The metadata for the call or None. metadata are additional headers
 
         :return: QueryAllBalancesResponse
         """
@@ -82,33 +93,48 @@ class BankRestClient(Bank):
         )
         return Parse(response, QueryAllBalancesResponse())
 
-    def TotalSupply(self, request: QueryTotalSupplyRequest) -> QueryTotalSupplyResponse:
+    def TotalSupply(
+        self,
+        request: QueryTotalSupplyRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryTotalSupplyResponse:
         """
         Query total supply of all denominations.
 
         :param request: QueryTotalSupplyRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
 
         :return: QueryTotalSupplyResponse
         """
         response = self._rest_api.get(f"{self.API_URL}/supply", request)
         return Parse(response, QueryTotalSupplyResponse())
 
-    def SupplyOf(self, request: QuerySupplyOfRequest) -> QuerySupplyOfResponse:
+    def SupplyOf(
+        self,
+        request: QuerySupplyOfRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QuerySupplyOfResponse:
         """
         Query total supply of specific denomination.
 
         :param request: QuerySupplyOfRequest with denomination
+        :param metadata: The metadata for the call or None. metadata are additional headers
 
         :return: QuerySupplyOfResponse
         """
         response = self._rest_api.get(f"{self.API_URL}/supply/{request.denom}")
         return Parse(response, QuerySupplyOfResponse())
 
-    def Params(self, request: QueryParamsRequest) -> QueryParamsResponse:
+    def Params(
+        self,
+        request: QueryParamsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryParamsResponse:
         """
         Query the parameters of bank module.
 
         :param request: QueryParamsRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
 
         :return: QueryParamsResponse
         """
@@ -116,12 +142,15 @@ class BankRestClient(Bank):
         return Parse(response, QueryParamsResponse())
 
     def DenomMetadata(
-        self, request: QueryDenomMetadataRequest
+        self,
+        request: QueryDenomMetadataRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryDenomMetadataResponse:
         """
         Query the client metadata for all registered coin denominations.
 
         :param request: QueryDenomMetadataRequest with denomination
+        :param metadata: The metadata for the call or None. metadata are additional headers
 
         :return: QueryDenomMetadataResponse
         """
@@ -129,12 +158,15 @@ class BankRestClient(Bank):
         return Parse(response, QueryDenomMetadataResponse())
 
     def DenomsMetadata(
-        self, request: QueryDenomsMetadataRequest
+        self,
+        request: QueryDenomsMetadataRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryDenomsMetadataResponse:
         """
         Query the client metadata of a given coin denomination.
 
         :param request: QueryDenomsMetadataRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
 
         :return: QueryDenomsMetadataResponse
         """

--- a/cosmpy/common/rest_client.py
+++ b/cosmpy/common/rest_client.py
@@ -20,7 +20,7 @@
 """Implementation of REST api client."""
 import base64
 import json
-from typing import List, Optional
+from typing import List, Optional, Tuple
 from urllib.parse import urlencode
 
 import requests
@@ -45,13 +45,16 @@ class RestClient:
         url_base_path: str,
         request: Optional[Message] = None,
         used_params: Optional[List[str]] = None,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> bytes:
         """
         Send a GET request.
 
         :param url_base_path: URL base path
         :param request: Protobuf coded request
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :param used_params: Parameters to be removed from request after converting it to dict
+        :param metadata: The metadata for the call or None. metadata are additional headers
 
         :raises RuntimeError: if response code is not 200
 
@@ -60,8 +63,11 @@ class RestClient:
         url = self._make_url(
             url_base_path=url_base_path, request=request, used_params=used_params
         )
-
-        response = self._session.get(url=url)
+        headers = {}
+        if metadata:
+            for key, value in metadata:
+                headers[key] = value
+        response = self._session.get(url=url, headers=headers)
         if response.status_code != 200:
             raise RuntimeError(
                 f"Error when sending a GET request.\n Response: {response.status_code}, {str(response.content)})"

--- a/cosmpy/cosmwasm/interface.py
+++ b/cosmpy/cosmwasm/interface.py
@@ -20,6 +20,7 @@
 """Interface for the Wasm functionality of CosmosSDK."""
 
 from abc import ABC, abstractmethod
+from typing import Optional, Tuple
 
 from cosmpy.protos.cosmwasm.wasm.v1.query_pb2 import (
     QueryAllContractStateRequest,
@@ -46,92 +47,115 @@ class CosmWasm(ABC):
 
     @abstractmethod
     def ContractInfo(
-        self, request: QueryContractInfoRequest
+        self,
+        request: QueryContractInfoRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryContractInfoResponse:
         """
         Get the contract meta data.
 
         :param request: QueryContractInfoRequest
-
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryContractInfoResponse
         """
 
     @abstractmethod
     def ContractHistory(
-        self, request: QueryContractHistoryRequest
+        self,
+        request: QueryContractHistoryRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryContractHistoryResponse:
         """
         Get the contract code history.
 
         :param request: QueryContractHistoryRequest
-
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryContractHistoryResponse
         """
 
     @abstractmethod
     def ContractsByCode(
-        self, request: QueryContractsByCodeRequest
+        self,
+        request: QueryContractsByCodeRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryContractsByCodeResponse:
         """
         List all smart contracts for a code id.
 
         :param request: QueryContractsByCodeRequest
-
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryContractsByCodeResponse
         """
 
     @abstractmethod
     def AllContractState(
-        self, request: QueryAllContractStateRequest
+        self,
+        request: QueryAllContractStateRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryAllContractStateResponse:
         """
         Get all raw store data for a single contract.
 
         :param request: QueryAllContractStateRequest
-
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryAllContractStateResponse
         """
 
     @abstractmethod
     def RawContractState(
-        self, request: QueryRawContractStateRequest
+        self,
+        request: QueryRawContractStateRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryRawContractStateResponse:
         """
         Get single key from the raw store data of a contract.
 
         :param request: QueryRawContractStateRequest
-
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryRawContractStateResponse
         """
 
     @abstractmethod
     def SmartContractState(
-        self, request: QuerySmartContractStateRequest
+        self,
+        request: QuerySmartContractStateRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QuerySmartContractStateResponse:
         """
         Get smart query result from the contract.
 
         :param request: QuerySmartContractStateRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
 
         :return: QuerySmartContractStateResponse
         """
 
     @abstractmethod
-    def Code(self, request: QueryCodeRequest) -> QueryCodeResponse:
+    def Code(
+        self,
+        request: QueryCodeRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryCodeResponse:
         """
         Get the binary code and metadata for a singe wasm code.
 
         :param request: QueryCodeRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
 
         :return: QueryCodeResponse
         """
 
     @abstractmethod
-    def Codes(self, request: QueryCodesRequest) -> QueryCodesResponse:
+    def Codes(
+        self,
+        request: QueryCodesRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryCodesResponse:
         """
         Get the metadata for all stored wasm codes.
 
         :param request: QueryCodesRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
 
         :return: QueryCodesResponse
         """

--- a/cosmpy/cosmwasm/rest_client.py
+++ b/cosmpy/cosmwasm/rest_client.py
@@ -21,6 +21,7 @@
 
 import base64
 import json
+from typing import Optional, Tuple
 
 from google.protobuf.json_format import Parse, ParseDict
 
@@ -63,13 +64,15 @@ class CosmWasmRestClient(CosmWasm):
         self._rest_api = rest_api
 
     def ContractInfo(
-        self, request: QueryContractInfoRequest
+        self,
+        request: QueryContractInfoRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryContractInfoResponse:
         """
         Get the contract meta data.
 
         :param request: QueryContractInfoRequest
-
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryContractInfoResponse
         """
         response = self._rest_api.get(
@@ -78,13 +81,15 @@ class CosmWasmRestClient(CosmWasm):
         return Parse(response, QueryContractInfoResponse())
 
     def ContractHistory(
-        self, request: QueryContractHistoryRequest
+        self,
+        request: QueryContractHistoryRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryContractHistoryResponse:
         """
         Get the contract code history.
 
         :param request: QueryContractHistoryRequest
-
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryContractHistoryResponse
         """
         response = self._rest_api.get(
@@ -96,12 +101,15 @@ class CosmWasmRestClient(CosmWasm):
         )
 
     def ContractsByCode(
-        self, request: QueryContractsByCodeRequest
+        self,
+        request: QueryContractsByCodeRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryContractsByCodeResponse:
         """
         List all smart contracts for a code id.
 
         :param request: QueryContractsByCodeRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
 
         :return: QueryContractsByCodeResponse
         """
@@ -111,12 +119,15 @@ class CosmWasmRestClient(CosmWasm):
         return Parse(response, QueryContractsByCodeResponse())
 
     def AllContractState(
-        self, request: QueryAllContractStateRequest
+        self,
+        request: QueryAllContractStateRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryAllContractStateResponse:
         """
         Get all raw store data for a single contract.
 
         :param request: QueryAllContractStateRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
 
         :return: QueryAllContractStateResponse
         """
@@ -126,12 +137,15 @@ class CosmWasmRestClient(CosmWasm):
         return Parse(response, QueryAllContractStateResponse())
 
     def RawContractState(
-        self, request: QueryRawContractStateRequest
+        self,
+        request: QueryRawContractStateRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryRawContractStateResponse:
         """
         Get single key from the raw store data of a contract.
 
         :param request: QueryRawContractStateRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
 
         :return: QueryRawContractStateResponse
         """
@@ -149,12 +163,15 @@ class CosmWasmRestClient(CosmWasm):
         )
 
     def SmartContractState(
-        self, request: QuerySmartContractStateRequest
+        self,
+        request: QuerySmartContractStateRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QuerySmartContractStateResponse:
         """
         Get smart query result from the contract.
 
         :param request: QuerySmartContractStateRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
 
         :return: QuerySmartContractStateResponse
         """
@@ -169,11 +186,16 @@ class CosmWasmRestClient(CosmWasm):
             self._fix_state_response(response), QuerySmartContractStateResponse()
         )
 
-    def Code(self, request: QueryCodeRequest) -> QueryCodeResponse:
+    def Code(
+        self,
+        request: QueryCodeRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryCodeResponse:
         """
         Get the binary code and metadata for a single wasm code.
 
         :param request: QueryCodeRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
 
         :return: QueryCodeResponse
         """
@@ -183,11 +205,16 @@ class CosmWasmRestClient(CosmWasm):
 
         return Parse(response, QueryCodeResponse())
 
-    def Codes(self, request: QueryCodesRequest) -> QueryCodesResponse:
+    def Codes(
+        self,
+        request: QueryCodesRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryCodesResponse:
         """
         Get the metadata for all stored wasm codes.
 
         :param request: QueryCodesRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
 
         :return: QueryCodesResponse
         """

--- a/cosmpy/distribution/interface.py
+++ b/cosmpy/distribution/interface.py
@@ -20,6 +20,7 @@
 """Interface for the Distribution functionality of CosmosSDK."""
 
 from abc import ABC, abstractmethod
+from typing import Optional, Tuple
 
 from cosmpy.protos.cosmos.distribution.v1beta1.query_pb2 import (
     QueryCommunityPoolResponse,
@@ -54,45 +55,61 @@ class Distribution(ABC):
 
     @abstractmethod
     def DelegationTotalRewards(
-        self, request: QueryDelegationTotalRewardsRequest
+        self,
+        request: QueryDelegationTotalRewardsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryDelegationTotalRewardsResponse:
         """
         DelegationTotalRewards queries the total rewards accrued by each validator.
 
         :param request: a QueryDelegationTotalRewardsRequest instance
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: a QueryDelegationTotalRewardsResponse instance
         """
 
     @abstractmethod
     def DelegationRewards(
-        self, request: QueryDelegationRewardsRequest
+        self,
+        request: QueryDelegationRewardsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryDelegationRewardsResponse:
         """
         DelegationRewards queries the total rewards accrued by a delegation.
 
         :param request: a QueryDelegationRewardsRequest instance
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: a QueryDelegationRewardsResponse instance
         """
 
     @abstractmethod
     def DelegatorValidators(
-        self, request: QueryDelegatorValidatorsRequest
+        self,
+        request: QueryDelegatorValidatorsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryDelegatorValidatorsResponse:
         """
         DelegatorValidators queries the validators of a delegator.
 
         :param request: a QueryDelegatorValidatorsRequest instance
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: a QueryDelegatorValidatorsResponse instance
         """
 
     @abstractmethod
     def DelegatorWithdrawAddress(
-        self, request: QueryDelegatorWithdrawAddressRequest
+        self,
+        request: QueryDelegatorWithdrawAddressRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryDelegatorWithdrawAddressResponse:
         """
         DelegatorWithdrawAddress queries withdraw address of a delegator.
 
         :param request: a QueryDelegatorWithdrawAddressRequest instance
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: a QueryDelegatorWithdrawAddressResponse instance
         """
 
@@ -106,33 +123,45 @@ class Distribution(ABC):
 
     @abstractmethod
     def ValidatorCommission(
-        self, request: QueryValidatorCommissionRequest
+        self,
+        request: QueryValidatorCommissionRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryValidatorCommissionResponse:
         """
         ValidatorCommission queries accumulated commission for a validator.
 
         :param request: QueryValidatorCommissionRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: QueryValidatorCommissionResponse
         """
 
     @abstractmethod
     def ValidatorOutstandingRewards(
-        self, request: QueryValidatorOutstandingRewardsRequest
+        self,
+        request: QueryValidatorOutstandingRewardsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryValidatorOutstandingRewardsResponse:
         """
         ValidatorOutstandingRewards queries rewards of a validator address.
 
         :param request: QueryValidatorOutstandingRewardsRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: QueryValidatorOutstandingRewardsResponse
         """
 
     @abstractmethod
     def ValidatorSlashes(
-        self, request: QueryValidatorSlashesRequest
+        self,
+        request: QueryValidatorSlashesRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryValidatorSlashesResponse:
         """
         ValidatorSlashes queries slash events of a validator.
 
         :param request: QueryValidatorSlashesRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: QueryValidatorSlashesResponse
         """

--- a/cosmpy/distribution/rest_client.py
+++ b/cosmpy/distribution/rest_client.py
@@ -18,6 +18,7 @@
 # ------------------------------------------------------------------------------
 
 """Implementation of Distribution interface using REST."""
+from typing import Optional, Tuple
 
 from google.protobuf.json_format import Parse
 
@@ -66,12 +67,16 @@ class DistributionRestClient(Distribution):
         return Parse(json_response, QueryCommunityPoolResponse())
 
     def DelegationTotalRewards(
-        self, request: QueryDelegationTotalRewardsRequest
+        self,
+        request: QueryDelegationTotalRewardsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryDelegationTotalRewardsResponse:
         """
         DelegationTotalRewards queries the total rewards accrued by each validator.
 
         :param request: a QueryDelegationTotalRewardsRequest instance
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: a QueryDelegationTotalRewardsResponse instance
         """
         json_response = self._rest_api.get(
@@ -80,12 +85,16 @@ class DistributionRestClient(Distribution):
         return Parse(json_response, QueryDelegationTotalRewardsResponse())
 
     def DelegationRewards(
-        self, request: QueryDelegationRewardsRequest
+        self,
+        request: QueryDelegationRewardsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryDelegationRewardsResponse:
         """
         DelegationRewards queries the total rewards accrued by a delegation.
 
         :param request: a QueryDelegationRewardsRequest instance
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: a QueryDelegationRewardsResponse instance
         """
         json_response = self._rest_api.get(
@@ -94,12 +103,16 @@ class DistributionRestClient(Distribution):
         return Parse(json_response, QueryDelegationRewardsResponse())
 
     def DelegatorValidators(
-        self, request: QueryDelegatorValidatorsRequest
+        self,
+        request: QueryDelegatorValidatorsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryDelegatorValidatorsResponse:
         """
         DelegatorValidators queries the validators of a delegator.
 
         :param request: a QueryDelegatorValidatorsRequest instance
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: a QueryDelegatorValidatorsResponse instance
         """
         json_response = self._rest_api.get(
@@ -108,12 +121,16 @@ class DistributionRestClient(Distribution):
         return Parse(json_response, QueryDelegatorValidatorsResponse())
 
     def DelegatorWithdrawAddress(
-        self, request: QueryDelegatorWithdrawAddressRequest
+        self,
+        request: QueryDelegatorWithdrawAddressRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryDelegatorWithdrawAddressResponse:
         """
         DelegatorWithdrawAddress queries withdraw address of a delegator.
 
         :param request: a QueryDelegatorWithdrawAddressRequest instance
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: a QueryDelegatorWithdrawAddressResponse instance
         """
         json_response = self._rest_api.get(
@@ -131,12 +148,16 @@ class DistributionRestClient(Distribution):
         return Parse(json_response, QueryParamsResponse())
 
     def ValidatorCommission(
-        self, request: QueryValidatorCommissionRequest
+        self,
+        request: QueryValidatorCommissionRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryValidatorCommissionResponse:
         """
         ValidatorCommission queries accumulated commission for a validator.
 
         :param request: QueryValidatorCommissionRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: QueryValidatorCommissionResponse
         """
         json_response = self._rest_api.get(
@@ -145,12 +166,16 @@ class DistributionRestClient(Distribution):
         return Parse(json_response, QueryValidatorCommissionResponse())
 
     def ValidatorOutstandingRewards(
-        self, request: QueryValidatorOutstandingRewardsRequest
+        self,
+        request: QueryValidatorOutstandingRewardsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryValidatorOutstandingRewardsResponse:
         """
         ValidatorOutstandingRewards queries rewards of a validator address.
 
         :param request: QueryValidatorOutstandingRewardsRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: QueryValidatorOutstandingRewardsResponse
         """
         json_response = self._rest_api.get(
@@ -159,12 +184,16 @@ class DistributionRestClient(Distribution):
         return Parse(json_response, QueryValidatorOutstandingRewardsResponse())
 
     def ValidatorSlashes(
-        self, request: QueryValidatorSlashesRequest
+        self,
+        request: QueryValidatorSlashesRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryValidatorSlashesResponse:
         """
         ValidatorSlashes queries slash events of a validator.
 
         :param request: QueryValidatorSlashesRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: QueryValidatorSlashesResponse
         """
         json_response = self._rest_api.get(

--- a/cosmpy/evidence/interface.py
+++ b/cosmpy/evidence/interface.py
@@ -19,6 +19,7 @@
 """Interface for the Evidence functionality of CosmosSDK."""
 
 from abc import ABC, abstractmethod
+from typing import Optional, Tuple
 
 from cosmpy.protos.cosmos.evidence.v1beta1.query_pb2 import (
     QueryAllEvidenceRequest,
@@ -32,21 +33,29 @@ class Evidence(ABC):
     """Evidence abstract class."""
 
     @abstractmethod
-    def Evidence(self, request: QueryEvidenceRequest) -> QueryEvidenceResponse:
+    def Evidence(
+        self,
+        request: QueryEvidenceRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryEvidenceResponse:
         """
         Evidence queries evidence based on evidence hash.
 
         :param request: QueryEvidenceRequest
-
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryEvidenceResponse
         """
 
     @abstractmethod
-    def AllEvidence(self, request: QueryAllEvidenceRequest) -> QueryAllEvidenceResponse:
+    def AllEvidence(
+        self,
+        request: QueryAllEvidenceRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryAllEvidenceResponse:
         """
         AllEvidence queries all evidence.
 
         :param request: QueryAllEvidenceRequest
-
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryAllEvidenceResponse
         """

--- a/cosmpy/evidence/rest_client.py
+++ b/cosmpy/evidence/rest_client.py
@@ -18,6 +18,7 @@
 # ------------------------------------------------------------------------------
 
 """Implementation of Evidence interface using REST."""
+from typing import Optional, Tuple
 
 from google.protobuf.json_format import Parse
 
@@ -44,12 +45,16 @@ class EvidenceRestClient(Evidence):
         """
         self._rest_api = rest_api
 
-    def Evidence(self, request: QueryEvidenceRequest) -> QueryEvidenceResponse:
+    def Evidence(
+        self,
+        request: QueryEvidenceRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryEvidenceResponse:
         """
         Evidence queries evidence based on evidence hash.
 
         :param request: QueryEvidenceRequest
-
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryEvidenceResponse
         """
         json_response = self._rest_api.get(
@@ -57,11 +62,16 @@ class EvidenceRestClient(Evidence):
         )
         return Parse(json_response, QueryEvidenceResponse())
 
-    def AllEvidence(self, request: QueryAllEvidenceRequest) -> QueryAllEvidenceResponse:
+    def AllEvidence(
+        self,
+        request: QueryAllEvidenceRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryAllEvidenceResponse:
         """
         AllEvidence queries all evidence.
 
         :param request: QueryAllEvidenceRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
 
         :return: QueryAllEvidenceResponse
         """

--- a/cosmpy/gov/interface.py
+++ b/cosmpy/gov/interface.py
@@ -19,6 +19,7 @@
 """Interface for the Gov functionality of CosmosSDK."""
 
 from abc import ABC, abstractmethod
+from typing import Optional, Tuple
 
 from cosmpy.protos.cosmos.gov.v1beta1.query_pb2 import (
     QueryDepositRequest,
@@ -44,80 +45,120 @@ class Gov(ABC):
     """Gov abstract class."""
 
     @abstractmethod
-    def Proposal(self, request: QueryProposalRequest) -> QueryProposalResponse:
+    def Proposal(
+        self,
+        request: QueryProposalRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryProposalResponse:
         """
         Proposal queries proposal details based on ProposalID.
 
         :param request: QueryProposalRequest with proposal id
+        :param metadata: The metadata for the call or None. metadata are additional headers
 
         :return: QueryProposalResponse
         """
 
     @abstractmethod
-    def Proposals(self, request: QueryProposalsRequest) -> QueryProposalsResponse:
+    def Proposals(
+        self,
+        request: QueryProposalsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryProposalsResponse:
         """
         Proposals queries all proposals based on given status.
 
         :param request: QueryProposalsRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
 
         :return: QueryProposalsResponse
         """
 
     @abstractmethod
-    def Vote(self, request: QueryVoteRequest) -> QueryVoteResponse:
+    def Vote(
+        self,
+        request: QueryVoteRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryVoteResponse:
         """
         Vote queries voted information based on proposalID, voterAddr.
 
         :param request: QueryVoteRequest with voter and proposal id
+        :param metadata: The metadata for the call or None. metadata are additional headers
 
         :return: QueryVoteResponse
         """
 
     @abstractmethod
-    def Votes(self, request: QueryVotesRequest) -> QueryVotesResponse:
+    def Votes(
+        self,
+        request: QueryVotesRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryVotesResponse:
         """
         Votes queries votes of a given proposal.
 
         :param request: QueryVotesResponse with proposal id
+        :param metadata: The metadata for the call or None. metadata are additional headers
 
         :return: QueryVotesResponse
         """
 
     @abstractmethod
-    def Params(self, request: QueryParamsRequest) -> QueryParamsResponse:
+    def Params(
+        self,
+        request: QueryParamsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryParamsResponse:
         """
         Params queries all parameters of the gov module.
 
         :param request: QueryParamsRequest with params_type
+        :param metadata: The metadata for the call or None. metadata are additional headers
 
         :return: QueryParamsResponse
         """
 
     @abstractmethod
-    def Deposit(self, request: QueryDepositRequest) -> QueryDepositResponse:
+    def Deposit(
+        self,
+        request: QueryDepositRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryDepositResponse:
         """
         Deposit queries single deposit information based proposalID, depositAddr.
 
         :param request: QueryDepositRequest with depositor and proposal_id
+        :param metadata: The metadata for the call or None. metadata are additional headers
 
         :return: QueryDepositResponse
         """
 
     @abstractmethod
-    def Deposits(self, request: QueryDepositsRequest) -> QueryDepositsResponse:
+    def Deposits(
+        self,
+        request: QueryDepositsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryDepositsResponse:
         """Deposits queries all deposits of a single proposal.
 
         :param request: QueryDepositsRequest with proposal_id
+        :param metadata: The metadata for the call or None. metadata are additional headers
 
         :return: QueryDepositsResponse
         """
 
     @abstractmethod
-    def TallyResult(self, request: QueryTallyResultRequest) -> QueryTallyResultResponse:
+    def TallyResult(
+        self,
+        request: QueryTallyResultRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryTallyResultResponse:
         """
         Tally Result queries the tally of a proposal vote.
 
         :param request: QueryTallyResultRequest with proposal_id
+        :param metadata: The metadata for the call or None. metadata are additional headers
 
         :return: QueryTallyResultResponse
         """

--- a/cosmpy/gov/rest_client.py
+++ b/cosmpy/gov/rest_client.py
@@ -17,6 +17,7 @@
 #
 # ------------------------------------------------------------------------------
 """Implementation of Gov interface using REST."""
+from typing import Optional, Tuple
 
 from google.protobuf.json_format import Parse
 
@@ -55,11 +56,16 @@ class GovRestClient(Gov):
         """
         self._rest_api = rest_api
 
-    def Proposal(self, request: QueryProposalRequest) -> QueryProposalResponse:
+    def Proposal(
+        self,
+        request: QueryProposalRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryProposalResponse:
         """
         Proposal queries proposal details based on ProposalID.
 
         :param request: QueryProposalRequest with proposal id
+        :param metadata: The metadata for the call or None. metadata are additional headers
 
         :return: QueryProposalResponse
         """
@@ -68,11 +74,16 @@ class GovRestClient(Gov):
         )
         return Parse(json_response, QueryProposalResponse())
 
-    def Proposals(self, request: QueryProposalsRequest) -> QueryProposalsResponse:
+    def Proposals(
+        self,
+        request: QueryProposalsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryProposalsResponse:
         """
         Proposals queries all proposals based on given status.
 
         :param request: QueryProposalsRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
 
         :return: QueryProposalsResponse
         """
@@ -82,11 +93,16 @@ class GovRestClient(Gov):
         )
         return Parse(json_response, QueryProposalsResponse())
 
-    def Vote(self, request: QueryVoteRequest) -> QueryVoteResponse:
+    def Vote(
+        self,
+        request: QueryVoteRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryVoteResponse:
         """
         Vote queries voted information based on proposalID, voterAddr.
 
         :param request: QueryVoteRequest with voter and proposal id
+        :param metadata: The metadata for the call or None. metadata are additional headers
 
         :return: QueryVoteResponse
         """
@@ -95,11 +111,16 @@ class GovRestClient(Gov):
         )
         return Parse(json_response, QueryVoteResponse())
 
-    def Votes(self, request: QueryVotesRequest) -> QueryVotesResponse:
+    def Votes(
+        self,
+        request: QueryVotesRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryVotesResponse:
         """
         Votes queries votes of a given proposal.
 
         :param request: QueryVotesResponse with proposal id
+        :param metadata: The metadata for the call or None. metadata are additional headers
 
         :return: QueryVotesResponse
         """
@@ -110,11 +131,16 @@ class GovRestClient(Gov):
         )
         return Parse(json_response, QueryVotesResponse())
 
-    def Params(self, request: QueryParamsRequest) -> QueryParamsResponse:
+    def Params(
+        self,
+        request: QueryParamsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryParamsResponse:
         """
         Params queries all parameters of the gov module.
 
         :param request: QueryParamsRequest with params_type
+        :param metadata: The metadata for the call or None. metadata are additional headers
 
         :return: QueryParamsResponse
         """
@@ -123,11 +149,16 @@ class GovRestClient(Gov):
         )
         return Parse(json_response, QueryParamsResponse())
 
-    def Deposit(self, request: QueryDepositRequest) -> QueryDepositResponse:
+    def Deposit(
+        self,
+        request: QueryDepositRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryDepositResponse:
         """
         Deposit queries single deposit information based proposalID, depositAddr.
 
         :param request: QueryDepositRequest with depositor and proposal_id
+        :param metadata: The metadata for the call or None. metadata are additional headers
 
         :return: QueryDepositResponse
         """
@@ -136,10 +167,15 @@ class GovRestClient(Gov):
         )
         return Parse(json_response, QueryDepositResponse())
 
-    def Deposits(self, request: QueryDepositsRequest) -> QueryDepositsResponse:
+    def Deposits(
+        self,
+        request: QueryDepositsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryDepositsResponse:
         """Deposits queries all deposits of a single proposal.
 
         :param request: QueryDepositsRequest with proposal_id
+        :param metadata: The metadata for the call or None. metadata are additional headers
 
         :return: QueryDepositsResponse
         """
@@ -150,11 +186,16 @@ class GovRestClient(Gov):
         )
         return Parse(json_response, QueryDepositsResponse())
 
-    def TallyResult(self, request: QueryTallyResultRequest) -> QueryTallyResultResponse:
+    def TallyResult(
+        self,
+        request: QueryTallyResultRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryTallyResultResponse:
         """
         Tally Result queries the tally of a proposal vote.
 
         :param request: QueryTallyResultRequest with proposal_id
+        :param metadata: The metadata for the call or None. metadata are additional headers
 
         :return: QueryTallyResultResponse
         """

--- a/cosmpy/ibc/applications/transfer/interface.py
+++ b/cosmpy/ibc/applications/transfer/interface.py
@@ -19,6 +19,7 @@
 """Interface for the IBC Applications Transfer functionality of CosmosSDK."""
 
 from abc import ABC, abstractmethod
+from typing import Optional, Tuple
 
 from cosmpy.protos.ibc.applications.transfer.v1.query_pb2 import (
     QueryDenomTraceRequest,
@@ -34,28 +35,43 @@ class IBCApplicationsTransfer(ABC):
     """IBC Applications Transfer abstract class."""
 
     @abstractmethod
-    def DenomTrace(self, request: QueryDenomTraceRequest) -> QueryDenomTraceResponse:
+    def DenomTrace(
+        self,
+        request: QueryDenomTraceRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryDenomTraceResponse:
         """
         DenomTrace queries a denomination trace information.
 
         :param request: QueryDenomTraceRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryDenomTraceResponse
         """
 
     @abstractmethod
-    def DenomTraces(self, request: QueryDenomTracesRequest) -> QueryDenomTracesResponse:
+    def DenomTraces(
+        self,
+        request: QueryDenomTracesRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryDenomTracesResponse:
         """
         DenomTraces queries all denomination traces.
 
         :param request: QueryDenomTracesRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryDenomTracesResponse
         """
 
     @abstractmethod
-    def Params(self, request: QueryParamsRequest) -> QueryParamsResponse:
+    def Params(
+        self,
+        request: QueryParamsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryParamsResponse:
         """
         Params queries all parameters of the ibc-transfer module.
 
         :param request: QueryParamsRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryParamsResponse
         """

--- a/cosmpy/ibc/applications/transfer/rest_client.py
+++ b/cosmpy/ibc/applications/transfer/rest_client.py
@@ -17,6 +17,8 @@
 #
 # ------------------------------------------------------------------------------
 """Implementation of IBC Applications Transfer  interface using REST."""
+from typing import Optional, Tuple
+
 from google.protobuf.json_format import Parse
 
 from cosmpy.common.rest_client import RestClient
@@ -46,11 +48,16 @@ class IBCApplicationsTransferRestClient(IBCApplicationsTransfer):
         """
         self._rest_api = rest_api
 
-    def DenomTrace(self, request: QueryDenomTraceRequest) -> QueryDenomTraceResponse:
+    def DenomTrace(
+        self,
+        request: QueryDenomTraceRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryDenomTraceResponse:
         """
         DenomTrace queries a denomination trace information.
 
         :param request: QueryDenomTraceRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryDenomTraceResponse
         """
         json_response = self._rest_api.get(
@@ -58,21 +65,31 @@ class IBCApplicationsTransferRestClient(IBCApplicationsTransfer):
         )
         return Parse(json_response, QueryDenomTraceResponse())
 
-    def DenomTraces(self, request: QueryDenomTracesRequest) -> QueryDenomTracesResponse:
+    def DenomTraces(
+        self,
+        request: QueryDenomTracesRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryDenomTracesResponse:
         """
         DenomTraces queries all denomination traces.
 
         :param request: QueryDenomTracesRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryDenomTracesResponse
         """
         json_response = self._rest_api.get(f"{self.API_URL}/denom_traces", request)
         return Parse(json_response, QueryDenomTracesResponse())
 
-    def Params(self, request: QueryParamsRequest) -> QueryParamsResponse:
+    def Params(
+        self,
+        request: QueryParamsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryParamsResponse:
         """
         Params queries all parameters of the ibc-transfer module.
 
         :param request: QueryParamsRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryParamsResponse
         """
         json_response = self._rest_api.get(f"{self.API_URL}/params")

--- a/cosmpy/ibc/core/channel/interface.py
+++ b/cosmpy/ibc/core/channel/interface.py
@@ -19,6 +19,7 @@
 """Interface for the IBC Core Channel functionality of CosmosSDK."""
 
 from abc import ABC, abstractmethod
+from typing import Optional, Tuple
 
 from cosmpy.protos.ibc.core.channel.v1.query_pb2 import (
     QueryChannelClientStateRequest,
@@ -54,140 +55,183 @@ class IBCCoreChannel(ABC):
     """IBC Core Channel abstract class."""
 
     @abstractmethod
-    def Channel(self, request: QueryChannelRequest) -> QueryChannelResponse:
+    def Channel(
+        self,
+        request: QueryChannelRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryChannelResponse:
         """
         Channel queries an IBC Channel.
 
         :param request: QueryChannelRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryChannelResponse
         """
 
     @abstractmethod
-    def Channels(self, request: QueryChannelsRequest) -> QueryChannelsResponse:
+    def Channels(
+        self,
+        request: QueryChannelsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryChannelsResponse:
         """
         Channels queries all the IBC channels of a chain.
 
         :param request: QueryChannelsRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryChannelsResponse
         """
 
     @abstractmethod
     def ConnectionChannels(
-        self, request: QueryConnectionChannelsRequest
+        self,
+        request: QueryConnectionChannelsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryConnectionChannelsResponse:
         """
         ConnectionChannels queries all the channels associated with a connection.
 
         :param request: QueryConnectionChannelsRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryConnectionChannelsResponse
         """
 
     @abstractmethod
     def ChannelClientState(
-        self, request: QueryChannelClientStateRequest
+        self,
+        request: QueryChannelClientStateRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryChannelClientStateResponse:
         """
         ChannelClientState queries for the client state for the channel associated with the provided channel identifiers.
 
         :param request: QueryChannelClientStateRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryChannelClientStateResponse
         """
 
     @abstractmethod
     def ChannelConsensusState(
-        self, request: QueryChannelConsensusStateRequest
+        self,
+        request: QueryChannelConsensusStateRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryChannelConsensusStateResponse:
         """
         ChannelConsensusState queries for the consensus state for the channel associated with the provided channel identifiers.
 
         :param request: QueryChannelConsensusStateRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryChannelConsensusStateResponse
         """
 
     @abstractmethod
     def PacketCommitment(
-        self, request: QueryPacketCommitmentRequest
+        self,
+        request: QueryPacketCommitmentRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryPacketCommitmentResponse:
         """
         PacketCommitment queries a stored packet commitment hash.
 
         :param request: QueryPacketCommitmentRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryPacketCommitmentResponse
         """
 
     @abstractmethod
     def PacketCommitments(
-        self, request: QueryPacketCommitmentsRequest
+        self,
+        request: QueryPacketCommitmentsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryPacketCommitmentsResponse:
         """
         PacketCommitments returns all the packet commitments hashes associated with a channel.
 
         :param request: QueryPacketCommitmentsRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryPacketCommitmentsResponse
         """
 
     @abstractmethod
     def PacketReceipt(
-        self, request: QueryPacketReceiptRequest
+        self,
+        request: QueryPacketReceiptRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryPacketReceiptResponse:
         """
         PacketReceipt queries if a given packet sequence has been received on the queried chain.
 
         :param request: QueryPacketReceiptRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryPacketReceiptResponse
         """
 
     @abstractmethod
     def PacketAcknowledgement(
-        self, request: QueryPacketAcknowledgementRequest
+        self,
+        request: QueryPacketAcknowledgementRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryPacketAcknowledgementResponse:
         """
         PacketAcknowledgement queries a stored packet acknowledgment hash.
 
         :param request: QueryPacketAcknowledgementRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryPacketAcknowledgementResponse
         """
 
     @abstractmethod
     def PacketAcknowledgements(
-        self, request: QueryPacketAcknowledgementsRequest
+        self,
+        request: QueryPacketAcknowledgementsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryPacketAcknowledgementsResponse:
         """
         PacketAcknowledgements returns all the packet acknowledgments associated with a channel.
 
         :param request: QueryPacketAcknowledgementsRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryPacketAcknowledgementsResponse
         """
 
     @abstractmethod
     def UnreceivedPackets(
-        self, request: QueryUnreceivedPacketsRequest
+        self,
+        request: QueryUnreceivedPacketsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryUnreceivedPacketsResponse:
         """
         UnreceivedPackets returns all the unreceived IBC packets associated with a channel and sequences.
 
         :param request: QueryUnreceivedPacketsRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryUnreceivedPacketsResponse
         """
 
     @abstractmethod
     def UnreceivedAcks(
-        self, request: QueryUnreceivedAcksRequest
+        self,
+        request: QueryUnreceivedAcksRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryUnreceivedAcksResponse:
         """
         UnreceivedAcks returns all the unreceived IBC acknowledgments associated with a channel and sequences.
 
         :param request: QueryUnreceivedAcksRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryUnreceivedAcksResponse
         """
 
     @abstractmethod
     def NextSequenceReceive(
-        self, request: QueryNextSequenceReceiveRequest
+        self,
+        request: QueryNextSequenceReceiveRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryNextSequenceReceiveResponse:
         """
         NextSequenceReceive returns the next receive sequence for a given channel.
 
         :param request: QueryNextSequenceReceiveRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryNextSequenceReceiveResponse
         """

--- a/cosmpy/ibc/core/channel/rest_client.py
+++ b/cosmpy/ibc/core/channel/rest_client.py
@@ -17,6 +17,8 @@
 #
 # ------------------------------------------------------------------------------
 """Implementation of IBC Applications Transfer  interface using REST."""
+from typing import Optional, Tuple
+
 from google.protobuf.json_format import Parse
 
 from cosmpy.common.rest_client import RestClient
@@ -64,11 +66,16 @@ class IBCCoreChannelRestClient(IBCCoreChannel):
         """
         self._rest_api = rest_api
 
-    def Channel(self, request: QueryChannelRequest) -> QueryChannelResponse:
+    def Channel(
+        self,
+        request: QueryChannelRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryChannelResponse:
         """
         Channel queries an IBC Channel.
 
         :param request: QueryChannelRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryChannelResponse
         """
         json_response = self._rest_api.get(
@@ -76,23 +83,31 @@ class IBCCoreChannelRestClient(IBCCoreChannel):
         )
         return Parse(json_response, QueryChannelResponse())
 
-    def Channels(self, request: QueryChannelsRequest) -> QueryChannelsResponse:
+    def Channels(
+        self,
+        request: QueryChannelsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryChannelsResponse:
         """
         Channels queries all the IBC channels of a chain.
 
         :param request: QueryChannelsRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryChannelsResponse
         """
         json_response = self._rest_api.get(f"{self.API_URL}/channels", request)
         return Parse(json_response, QueryChannelsResponse())
 
     def ConnectionChannels(
-        self, request: QueryConnectionChannelsRequest
+        self,
+        request: QueryConnectionChannelsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryConnectionChannelsResponse:
         """
         ConnectionChannels queries all the channels associated with a connection.
 
         :param request: QueryConnectionChannelsRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryConnectionChannelsResponse
         """
         json_response = self._rest_api.get(
@@ -101,12 +116,15 @@ class IBCCoreChannelRestClient(IBCCoreChannel):
         return Parse(json_response, QueryConnectionChannelsResponse())
 
     def ChannelClientState(
-        self, request: QueryChannelClientStateRequest
+        self,
+        request: QueryChannelClientStateRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryChannelClientStateResponse:
         """
         ChannelClientState queries for the client state for the channel associated with the provided channel identifiers.
 
         :param request: QueryChannelClientStateRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryChannelClientStateResponse
         """
         json_response = self._rest_api.get(
@@ -115,12 +133,15 @@ class IBCCoreChannelRestClient(IBCCoreChannel):
         return Parse(json_response, QueryChannelClientStateResponse())
 
     def ChannelConsensusState(
-        self, request: QueryChannelConsensusStateRequest
+        self,
+        request: QueryChannelConsensusStateRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryChannelConsensusStateResponse:
         """
         ChannelConsensusState queries for the consensus state for the channel associated with the provided channel identifiers.
 
         :param request: QueryChannelConsensusStateRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryChannelConsensusStateResponse
         """
         json_response = self._rest_api.get(
@@ -129,12 +150,15 @@ class IBCCoreChannelRestClient(IBCCoreChannel):
         return Parse(json_response, QueryChannelConsensusStateResponse())
 
     def PacketCommitment(
-        self, request: QueryPacketCommitmentRequest
+        self,
+        request: QueryPacketCommitmentRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryPacketCommitmentResponse:
         """
         PacketCommitment queries a stored packet commitment hash.
 
         :param request: QueryPacketCommitmentRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryPacketCommitmentResponse
         """
         json_response = self._rest_api.get(
@@ -143,12 +167,15 @@ class IBCCoreChannelRestClient(IBCCoreChannel):
         return Parse(json_response, QueryPacketCommitmentResponse())
 
     def PacketCommitments(
-        self, request: QueryPacketCommitmentsRequest
+        self,
+        request: QueryPacketCommitmentsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryPacketCommitmentsResponse:
         """
         PacketCommitments returns all the packet commitments hashes associated with a channel.
 
         :param request: QueryPacketCommitmentsRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryPacketCommitmentsResponse
         """
         json_response = self._rest_api.get(
@@ -158,12 +185,15 @@ class IBCCoreChannelRestClient(IBCCoreChannel):
         return Parse(json_response, QueryPacketCommitmentsResponse())
 
     def PacketReceipt(
-        self, request: QueryPacketReceiptRequest
+        self,
+        request: QueryPacketReceiptRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryPacketReceiptResponse:
         """
         PacketReceipt queries if a given packet sequence has been received on the queried chain.
 
         :param request: QueryPacketReceiptRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryPacketReceiptResponse
         """
         json_response = self._rest_api.get(
@@ -172,12 +202,15 @@ class IBCCoreChannelRestClient(IBCCoreChannel):
         return Parse(json_response, QueryPacketReceiptResponse())
 
     def PacketAcknowledgement(
-        self, request: QueryPacketAcknowledgementRequest
+        self,
+        request: QueryPacketAcknowledgementRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryPacketAcknowledgementResponse:
         """
         PacketAcknowledgement queries a stored packet acknowledgment hash.
 
         :param request: QueryPacketAcknowledgementRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryPacketAcknowledgementResponse
         """
         json_response = self._rest_api.get(
@@ -186,12 +219,15 @@ class IBCCoreChannelRestClient(IBCCoreChannel):
         return Parse(json_response, QueryPacketAcknowledgementResponse())
 
     def PacketAcknowledgements(
-        self, request: QueryPacketAcknowledgementsRequest
+        self,
+        request: QueryPacketAcknowledgementsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryPacketAcknowledgementsResponse:
         """
         PacketAcknowledgements returns all the packet acknowledgments associated with a channel.
 
         :param request: QueryPacketAcknowledgementsRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryPacketAcknowledgementsResponse
         """
         json_response = self._rest_api.get(
@@ -201,12 +237,15 @@ class IBCCoreChannelRestClient(IBCCoreChannel):
         return Parse(json_response, QueryPacketAcknowledgementsResponse())
 
     def UnreceivedPackets(
-        self, request: QueryUnreceivedPacketsRequest
+        self,
+        request: QueryUnreceivedPacketsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryUnreceivedPacketsResponse:
         """
         UnreceivedPackets returns all the unreceived IBC packets associated with a channel and sequences.
 
         :param request: QueryUnreceivedPacketsRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryUnreceivedPacketsResponse
         """
         json_response = self._rest_api.get(
@@ -216,12 +255,16 @@ class IBCCoreChannelRestClient(IBCCoreChannel):
         return Parse(json_response, QueryUnreceivedPacketsResponse())
 
     def UnreceivedAcks(
-        self, request: QueryUnreceivedAcksRequest
+        self,
+        request: QueryUnreceivedAcksRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryUnreceivedAcksResponse:
         """
         UnreceivedAcks returns all the unreceived IBC acknowledgments associated with a channel and sequences.
 
         :param request: QueryUnreceivedAcksRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: QueryUnreceivedAcksResponse
         """
         json_response = self._rest_api.get(
@@ -231,12 +274,16 @@ class IBCCoreChannelRestClient(IBCCoreChannel):
         return Parse(json_response, QueryUnreceivedAcksResponse())
 
     def NextSequenceReceive(
-        self, request: QueryNextSequenceReceiveRequest
+        self,
+        request: QueryNextSequenceReceiveRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryNextSequenceReceiveResponse:
         """
         NextSequenceReceive returns the next receive sequence for a given channel.
 
         :param request: QueryNextSequenceReceiveRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: QueryNextSequenceReceiveResponse
         """
         json_response = self._rest_api.get(

--- a/cosmpy/ibc/core/client/interface.py
+++ b/cosmpy/ibc/core/client/interface.py
@@ -19,6 +19,7 @@
 """Interface for the IBC Core Client functionality of CosmosSDK."""
 
 from abc import ABC, abstractmethod
+from typing import Optional, Tuple
 
 from cosmpy.protos.ibc.core.client.v1.query_pb2 import (
     QueryClientParamsRequest,
@@ -38,54 +39,71 @@ class IBCCoreClient(ABC):
     """IBC Core Client abstract class."""
 
     @abstractmethod
-    def ClientState(self, request: QueryClientStateRequest) -> QueryClientStateResponse:
+    def ClientState(
+        self,
+        request: QueryClientStateRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryClientStateResponse:
         """
         ClientState queries an IBC light client.
 
         :param request: QueryClientStateRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryClientStateResponse
         """
 
     @abstractmethod
     def ClientStates(
-        self, request: QueryClientStatesRequest
+        self,
+        request: QueryClientStatesRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryClientStatesResponse:
         """
         ClientStates queries all the IBC light clients of a chain.
 
         :param request: QueryClientStatesRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryClientStatesResponse
         """
 
     @abstractmethod
     def ConsensusState(
-        self, request: QueryConsensusStateRequest
+        self,
+        request: QueryConsensusStateRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryConsensusStateResponse:
         """
         ConsensusState queries a consensus state associated with a client state at a given height.
 
         :param request: QueryConsensusStateRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryConsensusStateResponse
         """
 
     @abstractmethod
     def ConsensusStates(
-        self, request: QueryConsensusStatesRequest
+        self,
+        request: QueryConsensusStatesRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryConsensusStatesResponse:
         """
         ConsensusStates queries all the consensus states associated with a given client.
 
         :param request: QueryConsensusStatesRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryConsensusStatesResponse
         """
 
     @abstractmethod
     def ClientParams(
-        self, request: QueryClientParamsRequest
+        self,
+        request: QueryClientParamsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryClientParamsResponse:
         """
         ClientParams queries all parameters of the IBC client.
 
         :param request: QueryClientParamsRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryClientParamsResponse
         """

--- a/cosmpy/ibc/core/client/rest_client.py
+++ b/cosmpy/ibc/core/client/rest_client.py
@@ -17,6 +17,8 @@
 #
 # ------------------------------------------------------------------------------
 """Implementation of IBC Applications Transfer  interface using REST."""
+from typing import Optional, Tuple
+
 from google.protobuf.json_format import Parse
 
 from cosmpy.common.rest_client import RestClient
@@ -48,11 +50,16 @@ class IBCCoreClientRestClient(IBCCoreClient):
         """
         self._rest_api = rest_api
 
-    def ClientState(self, request: QueryClientStateRequest) -> QueryClientStateResponse:
+    def ClientState(
+        self,
+        request: QueryClientStateRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryClientStateResponse:
         """
         ClientState queries an IBC light client.
 
         :param request: QueryClientStateRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryClientStateResponse
         """
         json_response = self._rest_api.get(
@@ -61,24 +68,30 @@ class IBCCoreClientRestClient(IBCCoreClient):
         return Parse(json_response, QueryClientStateResponse())
 
     def ClientStates(
-        self, request: QueryClientStatesRequest
+        self,
+        request: QueryClientStatesRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryClientStatesResponse:
         """
         ClientStates queries all the IBC light clients of a chain.
 
         :param request: QueryClientStatesRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryClientStatesResponse
         """
         json_response = self._rest_api.get(f"{self.API_URL}/client_states", request)
         return Parse(json_response, QueryClientStatesResponse())
 
     def ConsensusState(
-        self, request: QueryConsensusStateRequest
+        self,
+        request: QueryConsensusStateRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryConsensusStateResponse:
         """
         ConsensusState queries a consensus state associated with a client state at a given height.
 
         :param request: QueryConsensusStateRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryConsensusStateResponse
         """
         json_response = self._rest_api.get(
@@ -87,12 +100,15 @@ class IBCCoreClientRestClient(IBCCoreClient):
         return Parse(json_response, QueryConsensusStateResponse())
 
     def ConsensusStates(
-        self, request: QueryConsensusStatesRequest
+        self,
+        request: QueryConsensusStatesRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryConsensusStatesResponse:
         """
         ConsensusStates queries all the consensus states associated with a given client.
 
         :param request: QueryConsensusStatesRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryConsensusStatesResponse
         """
         json_response = self._rest_api.get(
@@ -101,12 +117,15 @@ class IBCCoreClientRestClient(IBCCoreClient):
         return Parse(json_response, QueryConsensusStatesResponse())
 
     def ClientParams(
-        self, request: QueryClientParamsRequest
+        self,
+        request: QueryClientParamsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryClientParamsResponse:
         """
         ClientParams queries all parameters of the IBC client.
 
         :param request: QueryClientParamsRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryClientParamsResponse
         """
         json_response = self._rest_api.get("/ibc/client/v1beta1/params")

--- a/cosmpy/ibc/core/connection/interface.py
+++ b/cosmpy/ibc/core/connection/interface.py
@@ -19,6 +19,7 @@
 """Interface for the IBC Core Connection functionality of CosmosSDK."""
 
 from abc import ABC, abstractmethod
+from typing import Optional, Tuple
 
 from cosmpy.protos.ibc.core.connection.v1.query_pb2 import (
     QueryClientConnectionsRequest,
@@ -38,52 +39,71 @@ class IBCCoreConnection(ABC):
     """IBC Core Connection abstract class."""
 
     @abstractmethod
-    def Connection(self, request: QueryConnectionRequest) -> QueryConnectionResponse:
+    def Connection(
+        self,
+        request: QueryConnectionRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryConnectionResponse:
         """
         Connection queries an IBC connection end.
 
         :param request: QueryConnectionRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryConnectionResponse
         """  # noqa: D401
 
     @abstractmethod
-    def Connections(self, request: QueryConnectionsRequest) -> QueryConnectionsResponse:
+    def Connections(
+        self,
+        request: QueryConnectionsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryConnectionsResponse:
         """
         Connection queries all the IBC connections of a chain.
 
         :param request: QueryConnectionsRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryConnectionsResponse
         """  # noqa: D401
 
     @abstractmethod
     def ClientConnections(
-        self, request: QueryClientConnectionsRequest
+        self,
+        request: QueryClientConnectionsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryClientConnectionsResponse:
         """
         ClientConnection queries the connection paths associated with a client state.
 
         :param request: QueryClientConnectionsRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryClientConnectionsResponse
         """
 
     @abstractmethod
     def ConnectionClientState(
-        self, request: QueryConnectionClientStateRequest
+        self,
+        request: QueryConnectionClientStateRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryConnectionClientStateResponse:
         """
         ConnectionClientState queries the client state associated with the connection.
 
         :param request: QueryConnectionClientStateRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryConnectionClientStateResponse
         """
 
     @abstractmethod
     def ConnectionConsensusState(
-        self, request: QueryConnectionConsensusStateRequest
+        self,
+        request: QueryConnectionConsensusStateRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryConnectionConsensusStateResponse:
         """
         ConnectionConsensusState queries the consensus state associated with the connection.
 
         :param request: QueryConnectionConsensusStateRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryConnectionConsensusStateResponse
         """

--- a/cosmpy/ibc/core/connection/rest_client.py
+++ b/cosmpy/ibc/core/connection/rest_client.py
@@ -17,6 +17,8 @@
 #
 # ------------------------------------------------------------------------------
 """Implementation of IBC Applications Transfer  interface using REST."""
+from typing import Optional, Tuple
+
 from google.protobuf.json_format import Parse
 
 from cosmpy.common.rest_client import RestClient
@@ -48,11 +50,16 @@ class IBCCoreConnectionRestClient(IBCCoreConnection):
         """
         self._rest_api = rest_api
 
-    def Connection(self, request: QueryConnectionRequest) -> QueryConnectionResponse:
+    def Connection(
+        self,
+        request: QueryConnectionRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryConnectionResponse:
         """
         Connection queries an IBC connection end.
 
         :param request: QueryConnectionRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryConnectionResponse
         """  # noqa: D401
         json_response = self._rest_api.get(
@@ -60,23 +67,31 @@ class IBCCoreConnectionRestClient(IBCCoreConnection):
         )
         return Parse(json_response, QueryConnectionResponse())
 
-    def Connections(self, request: QueryConnectionsRequest) -> QueryConnectionsResponse:
+    def Connections(
+        self,
+        request: QueryConnectionsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryConnectionsResponse:
         """
         Connections queries all the IBC connections of a chain.
 
         :param request: QueryConnectionsRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryConnectionsResponse
         """  # noqa: D401
         json_response = self._rest_api.get(f"{self.API_URL}/connections", request)
         return Parse(json_response, QueryConnectionsResponse())
 
     def ClientConnections(
-        self, request: QueryClientConnectionsRequest
+        self,
+        request: QueryClientConnectionsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryClientConnectionsResponse:
         """
         ClientConnections queries the connection paths associated with a client state.
 
         :param request: QueryClientConnectionsRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryClientConnectionsResponse
         """
         json_response = self._rest_api.get(
@@ -85,12 +100,15 @@ class IBCCoreConnectionRestClient(IBCCoreConnection):
         return Parse(json_response, QueryClientConnectionsResponse())
 
     def ConnectionClientState(
-        self, request: QueryConnectionClientStateRequest
+        self,
+        request: QueryConnectionClientStateRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryConnectionClientStateResponse:
         """
         ConnectionClientState queries the client state associated with the connection.
 
         :param request: QueryConnectionClientStateRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryConnectionClientStateResponse
         """
         json_response = self._rest_api.get(
@@ -99,12 +117,15 @@ class IBCCoreConnectionRestClient(IBCCoreConnection):
         return Parse(json_response, QueryConnectionClientStateResponse())
 
     def ConnectionConsensusState(
-        self, request: QueryConnectionConsensusStateRequest
+        self,
+        request: QueryConnectionConsensusStateRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryConnectionConsensusStateResponse:
         """
         ConnectionConsensusState queries the consensus state associated with the connection.
 
         :param request: QueryConnectionConsensusStateRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryConnectionConsensusStateResponse
         """
         json_response = self._rest_api.get(

--- a/cosmpy/params/interface.py
+++ b/cosmpy/params/interface.py
@@ -20,6 +20,7 @@
 """Interface for the Params functionality of CosmosSDK."""
 
 from abc import ABC, abstractmethod
+from typing import Optional, Tuple
 
 from cosmpy.protos.cosmos.params.v1beta1.query_pb2 import (
     QueryParamsRequest,
@@ -31,10 +32,15 @@ class Params(ABC):
     """Params abstract class."""
 
     @abstractmethod
-    def Params(self, request: QueryParamsRequest) -> QueryParamsResponse:
+    def Params(
+        self,
+        request: QueryParamsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryParamsResponse:
         """
         Params queries a specific Cosmos SDK parameter.
 
         :param request: QueryParamsRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryParamsResponse
         """

--- a/cosmpy/params/rest_client.py
+++ b/cosmpy/params/rest_client.py
@@ -18,6 +18,7 @@
 # ------------------------------------------------------------------------------
 
 """Implementation of Params interface using REST."""
+from typing import Optional, Tuple
 
 from google.protobuf.json_format import Parse
 
@@ -42,11 +43,16 @@ class ParamsRestClient(Params):
         """
         self._rest_api = rest_api
 
-    def Params(self, request: QueryParamsRequest) -> QueryParamsResponse:
+    def Params(
+        self,
+        request: QueryParamsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryParamsResponse:
         """
         Params queries a specific Cosmos SDK parameter.
 
         :param request: QueryParamsRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryParamsResponse
         """
         json_response = self._rest_api.get(f"{self.API_URL}/params", request)

--- a/cosmpy/slashing/interface.py
+++ b/cosmpy/slashing/interface.py
@@ -19,6 +19,7 @@
 """Interface for the Slashing functionality of CosmosSDK."""
 
 from abc import ABC, abstractmethod
+from typing import Optional, Tuple
 
 from cosmpy.protos.cosmos.slashing.v1beta1.query_pb2 import (
     QueryParamsResponse,
@@ -41,23 +42,29 @@ class Slashing(ABC):
         """
 
     @abstractmethod
-    def SigningInfo(self, request: QuerySigningInfoRequest) -> QuerySigningInfoResponse:
+    def SigningInfo(
+        self,
+        request: QuerySigningInfoRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QuerySigningInfoResponse:
         """
         SigningInfo queries the signing info of given cons address.
 
         :param request: QuerySigningInfoRequest
-
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QuerySigningInfoResponse
         """
 
     @abstractmethod
     def SigningInfos(
-        self, request: QuerySigningInfosRequest
+        self,
+        request: QuerySigningInfosRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QuerySigningInfosResponse:
         """
         SigningInfos queries signing info of all validators.
 
         :param request: QuerySigningInfosRequest
-
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QuerySigningInfosResponse
         """

--- a/cosmpy/slashing/rest_client.py
+++ b/cosmpy/slashing/rest_client.py
@@ -17,6 +17,7 @@
 #
 # ------------------------------------------------------------------------------
 """Implementation of Slashing interface using REST."""
+from typing import Optional, Tuple
 
 from google.protobuf.json_format import Parse
 
@@ -55,12 +56,16 @@ class SlashingRestClient(Slashing):
         )
         return Parse(json_response, QueryParamsResponse())
 
-    def SigningInfo(self, request: QuerySigningInfoRequest) -> QuerySigningInfoResponse:
+    def SigningInfo(
+        self,
+        request: QuerySigningInfoRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QuerySigningInfoResponse:
         """
         SigningInfo queries the signing info of given cons address.
 
         :param request: QuerySigningInfoRequest
-
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QuerySigningInfoResponse
         """
         json_response = self._rest_api.get(
@@ -69,12 +74,15 @@ class SlashingRestClient(Slashing):
         return Parse(json_response, QuerySigningInfoResponse())
 
     def SigningInfos(
-        self, request: QuerySigningInfosRequest
+        self,
+        request: QuerySigningInfosRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QuerySigningInfosResponse:
         """
         SigningInfos queries signing info of all validators.
 
         :param request: QuerySigningInfosRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
 
         :return: QuerySigningInfosResponse
         """

--- a/cosmpy/staking/interface.py
+++ b/cosmpy/staking/interface.py
@@ -20,6 +20,7 @@
 """Interface for the Staking functionality of CosmosSDK."""
 
 from abc import ABC, abstractmethod
+from typing import Optional, Tuple
 
 from cosmpy.protos.cosmos.staking.v1beta1.query_pb2 import (
     QueryDelegationRequest,
@@ -57,145 +58,208 @@ class Staking(ABC):
     """Staking abstract class."""
 
     @abstractmethod
-    def Validators(self, request: QueryValidatorsRequest) -> QueryValidatorsResponse:
+    def Validators(
+        self,
+        request: QueryValidatorsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryValidatorsResponse:
         """
         Query all validators that match the given status.
 
         :param request: QueryValidatorsRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryValidatorsResponse
         """
 
     @abstractmethod
-    def Validator(self, request: QueryValidatorRequest) -> QueryValidatorResponse:
+    def Validator(
+        self,
+        request: QueryValidatorRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryValidatorResponse:
         """
         Query validator info for given validator address.
 
         :param request: QueryValidatorRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: QueryValidatorResponse
         """
 
     @abstractmethod
     def ValidatorDelegations(
-        self, request: QueryValidatorDelegationsRequest
+        self,
+        request: QueryValidatorDelegationsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryValidatorDelegationsResponse:
         """
         Query delegate info for given validator.
 
         :param request: QueryValidatorDelegationsRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: QueryValidatorDelegationsResponse
         """
 
     @abstractmethod
     def ValidatorUnbondingDelegations(
-        self, request: QueryValidatorUnbondingDelegationsRequest
+        self,
+        request: QueryValidatorUnbondingDelegationsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryValidatorUnbondingDelegationsResponse:
         """
         Query unbonding delegations of a validator.
 
          :param request: ValidatorUnbondingDelegations
-         :return: QueryValidatorUnbondingDelegationsResponse
+         :param metadata: The metadata for the call or None. metadata are additional headers         :return: QueryValidatorUnbondingDelegationsResponse
         """
 
     @abstractmethod
-    def Delegation(self, request: QueryDelegationRequest) -> QueryDelegationResponse:
+    def Delegation(
+        self,
+        request: QueryDelegationRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryDelegationResponse:
         """
         Query delegate info for given validator delegator pair.
 
         :param request: QueryDelegationRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: QueryDelegationResponse
         """
 
     @abstractmethod
     def UnbondingDelegation(
-        self, request: QueryUnbondingDelegationRequest
+        self,
+        request: QueryUnbondingDelegationRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryUnbondingDelegationResponse:
         """
         UnbondingDelegation queries unbonding info for given validator delegator pair.
 
         :param request: QueryUnbondingDelegationRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: QueryUnbondingDelegationResponse
         """
 
     @abstractmethod
     def DelegatorDelegations(
-        self, request: QueryDelegatorDelegationsRequest
+        self,
+        request: QueryDelegatorDelegationsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryDelegatorDelegationsResponse:
         """
         DelegatorDelegations queries all delegations of a given delegator address.
 
         :param request: QueryDelegatorDelegationsRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: QueryDelegatorDelegationsResponse
         """
 
     @abstractmethod
     def DelegatorUnbondingDelegations(
-        self, request: QueryDelegatorUnbondingDelegationsRequest
+        self,
+        request: QueryDelegatorUnbondingDelegationsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryDelegatorUnbondingDelegationsResponse:
         """
         DelegatorUnbondingDelegations queries all unbonding delegations of a given delegator address.
 
         :param request: QueryDelegatorUnbondingDelegationsRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: QueryDelegatorUnbondingDelegationsResponse
         """
 
     @abstractmethod
     def Redelegations(
-        self, request: QueryRedelegationsRequest
+        self,
+        request: QueryRedelegationsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryRedelegationsResponse:
         """
         Redelegations queries redelegations of given address.
 
         :param request: QueryRedelegationsRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: QueryRedelegationsResponse
         """
 
     @abstractmethod
     def DelegatorValidators(
-        self, request: QueryDelegatorValidatorsRequest
+        self,
+        request: QueryDelegatorValidatorsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryDelegatorValidatorsResponse:
         """
         DelegatorValidators queries all validators info for given delegator address.
 
         :param request: QueryDelegatorValidatorsRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: QueryDelegatorValidatorsRequest
         """
 
     @abstractmethod
     def DelegatorValidator(
-        self, request: QueryDelegatorValidatorRequest
+        self,
+        request: QueryDelegatorValidatorRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryDelegatorValidatorResponse:
         """
         DelegatorValidator queries validator info for given delegator validator pair.
 
         :param request: QueryDelegatorValidatorRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: QueryDelegatorValidatorResponse
         """
 
     @abstractmethod
     def HistoricalInfo(
-        self, request: QueryHistoricalInfoRequest
+        self,
+        request: QueryHistoricalInfoRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryHistoricalInfoResponse:
         """
         HistoricalInfo queries the historical info for given height.
 
         :param request: QueryHistoricalInfoRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: QueryHistoricalInfoResponse
         """
 
     @abstractmethod
-    def Pool(self, request: QueryPoolRequest) -> QueryPoolResponse:
+    def Pool(
+        self,
+        request: QueryPoolRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryPoolResponse:
         """
         Pool queries the pool info.
 
         :param request: QueryPoolRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: QueryPoolResponse
         """
 
     @abstractmethod
-    def Params(self, request: QueryParamsRequest) -> QueryParamsResponse:
+    def Params(
+        self,
+        request: QueryParamsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryParamsResponse:
         """
         Parameters queries the staking parameters.
 
         :param request: QueryParamsRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: QueryParamsResponse
         """

--- a/cosmpy/staking/rest_client.py
+++ b/cosmpy/staking/rest_client.py
@@ -18,6 +18,7 @@
 # ------------------------------------------------------------------------------
 
 """Implementation of Staking interface using REST."""
+from typing import Optional, Tuple
 
 from google.protobuf.json_format import Parse
 
@@ -68,21 +69,33 @@ class StakingRestClient(Staking):
         """
         self._rest_api = rest_api
 
-    def Validators(self, request: QueryValidatorsRequest) -> QueryValidatorsResponse:
+    def Validators(
+        self,
+        request: QueryValidatorsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryValidatorsResponse:
         """
         Query all validators that match the given status.
 
         :param request: QueryValidatorsRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: QueryValidatorsResponse
         """
         json_response = self._rest_api.get(f"{self.API_URL}/validators", request)
         return Parse(json_response, QueryValidatorsResponse())
 
-    def Validator(self, request: QueryValidatorRequest) -> QueryValidatorResponse:
+    def Validator(
+        self,
+        request: QueryValidatorRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryValidatorResponse:
         """
         Query validator info for given validator address.
 
         :param request: QueryValidatorRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: QueryValidatorResponse
         """
         json_response = self._rest_api.get(
@@ -91,12 +104,16 @@ class StakingRestClient(Staking):
         return Parse(json_response, QueryValidatorResponse())
 
     def ValidatorDelegations(
-        self, request: QueryValidatorDelegationsRequest
+        self,
+        request: QueryValidatorDelegationsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryValidatorDelegationsResponse:
         """
         ValidatorDelegations queries delegate info for given validator.
 
         :param request: QueryValidatorDelegationsRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: QueryValidatorDelegationsResponse
         """
         json_response = self._rest_api.get(
@@ -107,12 +124,15 @@ class StakingRestClient(Staking):
         return Parse(json_response, QueryValidatorDelegationsResponse())
 
     def ValidatorUnbondingDelegations(
-        self, request: QueryValidatorUnbondingDelegationsRequest
+        self,
+        request: QueryValidatorUnbondingDelegationsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryValidatorUnbondingDelegationsResponse:
         """
         ValidatorUnbondingDelegations queries unbonding delegations of a validator.
 
         :param request: ValidatorUnbondingDelegations
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: QueryValidatorUnbondingDelegationsResponse
         """
         json_response = self._rest_api.get(
@@ -122,11 +142,17 @@ class StakingRestClient(Staking):
         )
         return Parse(json_response, QueryValidatorUnbondingDelegationsResponse())
 
-    def Delegation(self, request: QueryDelegationRequest) -> QueryDelegationResponse:
+    def Delegation(
+        self,
+        request: QueryDelegationRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryDelegationResponse:
         """
         Query delegate info for given validator delegator pair.
 
         :param request: QueryDelegationRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: QueryDelegationResponse
         """
         json_response = self._rest_api.get(
@@ -135,12 +161,16 @@ class StakingRestClient(Staking):
         return Parse(json_response, QueryDelegationResponse())
 
     def UnbondingDelegation(
-        self, request: QueryUnbondingDelegationRequest
+        self,
+        request: QueryUnbondingDelegationRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryUnbondingDelegationResponse:
         """
         UnbondingDelegation queries unbonding info for given validator delegator pair.
 
         :param request: QueryUnbondingDelegationRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: QueryUnbondingDelegationResponse
         """
         json_response = self._rest_api.get(
@@ -149,12 +179,16 @@ class StakingRestClient(Staking):
         return Parse(json_response, QueryUnbondingDelegationResponse())
 
     def DelegatorDelegations(
-        self, request: QueryDelegatorDelegationsRequest
+        self,
+        request: QueryDelegatorDelegationsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryDelegatorDelegationsResponse:
         """
         DelegatorDelegations queries all delegations of a given delegator address.
 
         :param request: QueryDelegatorDelegationsRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: QueryDelegatorDelegationsResponse
         """
         json_response = self._rest_api.get(
@@ -165,12 +199,16 @@ class StakingRestClient(Staking):
         return Parse(json_response, QueryDelegatorDelegationsResponse())
 
     def DelegatorUnbondingDelegations(
-        self, request: QueryDelegatorUnbondingDelegationsRequest
+        self,
+        request: QueryDelegatorUnbondingDelegationsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryDelegatorUnbondingDelegationsResponse:
         """
         DelegatorUnbondingDelegations queries all unbonding delegations of a given delegator address.
 
         :param request: QueryDelegatorUnbondingDelegationsRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: QueryDelegatorUnbondingDelegationsResponse
         """
         json_response = self._rest_api.get(
@@ -181,12 +219,16 @@ class StakingRestClient(Staking):
         return Parse(json_response, QueryDelegatorUnbondingDelegationsResponse())
 
     def Redelegations(
-        self, request: QueryRedelegationsRequest
+        self,
+        request: QueryRedelegationsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryRedelegationsResponse:
         """
         Redelegations queries redelegations of given address.
 
         :param request: QueryRedelegationsRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: QueryRedelegationsResponse
         """
         json_response = self._rest_api.get(
@@ -197,12 +239,16 @@ class StakingRestClient(Staking):
         return Parse(json_response, QueryRedelegationsResponse())
 
     def DelegatorValidators(
-        self, request: QueryDelegatorValidatorsRequest
+        self,
+        request: QueryDelegatorValidatorsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryDelegatorValidatorsResponse:
         """
         DelegatorValidators queries all validators info for given delegator address.
 
         :param request: QueryDelegatorValidatorsRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: QueryDelegatorValidatorsRequest
         """
         json_response = self._rest_api.get(
@@ -213,12 +259,16 @@ class StakingRestClient(Staking):
         return Parse(json_response, QueryDelegatorValidatorsResponse())
 
     def DelegatorValidator(
-        self, request: QueryDelegatorValidatorRequest
+        self,
+        request: QueryDelegatorValidatorRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryDelegatorValidatorResponse:
         """
         DelegatorValidator queries validator info for given delegator validator pair.
 
         :param request: QueryDelegatorValidatorRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: QueryDelegatorValidatorResponse
         """
         json_response = self._rest_api.get(
@@ -227,12 +277,16 @@ class StakingRestClient(Staking):
         return Parse(json_response, QueryDelegatorValidatorResponse())
 
     def HistoricalInfo(
-        self, request: QueryHistoricalInfoRequest
+        self,
+        request: QueryHistoricalInfoRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> QueryHistoricalInfoResponse:
         """
         HistoricalInfo queries the historical info for given height.
 
         :param request: QueryHistoricalInfoRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: QueryHistoricalInfoResponse
         """
         json_response = self._rest_api.get(
@@ -240,21 +294,33 @@ class StakingRestClient(Staking):
         )
         return Parse(json_response, QueryHistoricalInfoResponse())
 
-    def Pool(self, request: QueryPoolRequest) -> QueryPoolResponse:
+    def Pool(
+        self,
+        request: QueryPoolRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryPoolResponse:
         """
         Pool queries the pool info.
 
         :param request: QueryPoolRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: QueryPoolResponse
         """
         json_response = self._rest_api.get(f"{self.API_URL}/pool")
         return Parse(json_response, QueryPoolResponse())
 
-    def Params(self, request: QueryParamsRequest) -> QueryParamsResponse:
+    def Params(
+        self,
+        request: QueryParamsRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryParamsResponse:
         """
         Parameters queries the staking parameters.
 
         :param request: QueryParamsRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: QueryParamsResponse
         """
         json_response = self._rest_api.get(f"{self.API_URL}/params")

--- a/cosmpy/tendermint/interface.py
+++ b/cosmpy/tendermint/interface.py
@@ -19,6 +19,7 @@
 """Interface for the Cosmos Base Tendermint functionality of CosmosSDK."""
 
 from abc import ABC, abstractmethod
+from typing import Optional, Tuple
 
 from cosmpy.protos.cosmos.base.tendermint.v1beta1.query_pb2 import (
     GetBlockByHeightRequest,
@@ -40,61 +41,91 @@ class CosmosBaseTendermint(ABC):
     """Cosmos Base Tendermint abstract class."""
 
     @abstractmethod
-    def GetNodeInfo(self, request: GetNodeInfoRequest) -> GetNodeInfoResponse:
+    def GetNodeInfo(
+        self,
+        request: GetNodeInfoRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> GetNodeInfoResponse:
         """
         GetNodeInfo queries the current node info.
 
         :param request: GetNodeInfoRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: GetNodeInfoResponse
         """
 
     @abstractmethod
-    def GetSyncing(self, request: GetSyncingRequest) -> GetSyncingResponse:
+    def GetSyncing(
+        self,
+        request: GetSyncingRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> GetSyncingResponse:
         """
         GetSyncing queries node syncing.
 
         :param request: GetSyncingRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: GetSyncingResponse
         """
 
     @abstractmethod
-    def GetLatestBlock(self, request: GetLatestBlockRequest) -> GetLatestBlockResponse:
+    def GetLatestBlock(
+        self,
+        request: GetLatestBlockRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> GetLatestBlockResponse:
         """
         GetLatestBlock returns the latest block.
 
         :param request: GetLatestBlockRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: GetLatestBlockResponse
         """
 
     @abstractmethod
     def GetBlockByHeight(
-        self, request: GetBlockByHeightRequest
+        self,
+        request: GetBlockByHeightRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> GetBlockByHeightResponse:
         """
         GetBlockByHeight queries block for given height.
 
         :param request: GetBlockByHeightRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: GetBlockByHeightResponse
         """
 
     @abstractmethod
     def GetLatestValidatorSet(
-        self, request: GetLatestValidatorSetRequest
+        self,
+        request: GetLatestValidatorSetRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> GetLatestValidatorSetResponse:
         """
         GetLatestValidatorSet queries latest validator-set.
 
         :param request: GetLatestValidatorSetRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: GetLatestValidatorSetResponse
         """
 
     @abstractmethod
     def GetValidatorSetByHeight(
-        self, request: GetValidatorSetByHeightRequest
+        self,
+        request: GetValidatorSetByHeightRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> GetValidatorSetByHeightResponse:
         """
         GetValidatorSetByHeight queries validator-set at a given height.
 
         :param request: GetValidatorSetByHeightRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: GetValidatorSetByHeightResponse
         """

--- a/cosmpy/tendermint/rest_client.py
+++ b/cosmpy/tendermint/rest_client.py
@@ -17,6 +17,8 @@
 #
 # ------------------------------------------------------------------------------
 """Implementation of IBC Applications Transfer  interface using REST."""
+from typing import Optional, Tuple
+
 from google.protobuf.json_format import Parse
 
 from cosmpy.common.rest_client import RestClient
@@ -50,11 +52,17 @@ class CosmosBaseTendermintRestClient(CosmosBaseTendermint):
         """
         self._rest_api = rest_api
 
-    def GetNodeInfo(self, request: GetNodeInfoRequest) -> GetNodeInfoResponse:
+    def GetNodeInfo(
+        self,
+        request: GetNodeInfoRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> GetNodeInfoResponse:
         """
         GetNodeInfo queries the current node info.
 
         :param request: GetNodeInfoRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: GetNodeInfoResponse
         """
         json_response = self._rest_api.get(
@@ -62,11 +70,17 @@ class CosmosBaseTendermintRestClient(CosmosBaseTendermint):
         )
         return Parse(json_response, GetNodeInfoResponse())
 
-    def GetSyncing(self, request: GetSyncingRequest) -> GetSyncingResponse:
+    def GetSyncing(
+        self,
+        request: GetSyncingRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> GetSyncingResponse:
         """
         GetSyncing queries node syncing.
 
         :param request: GetSyncingRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: GetSyncingResponse
         """
         json_response = self._rest_api.get(
@@ -74,11 +88,17 @@ class CosmosBaseTendermintRestClient(CosmosBaseTendermint):
         )
         return Parse(json_response, GetSyncingResponse())
 
-    def GetLatestBlock(self, request: GetLatestBlockRequest) -> GetLatestBlockResponse:
+    def GetLatestBlock(
+        self,
+        request: GetLatestBlockRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> GetLatestBlockResponse:
         """
         GetLatestBlock returns the latest block.
 
         :param request: GetLatestBlockRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: GetLatestBlockResponse
         """
         json_response = self._rest_api.get(
@@ -87,24 +107,32 @@ class CosmosBaseTendermintRestClient(CosmosBaseTendermint):
         return Parse(json_response, GetLatestBlockResponse())
 
     def GetBlockByHeight(
-        self, request: GetBlockByHeightRequest
+        self,
+        request: GetBlockByHeightRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> GetBlockByHeightResponse:
         """
         GetBlockByHeight queries block for given height.
 
         :param request: GetBlockByHeightRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: GetBlockByHeightResponse
         """
         json_response = self._rest_api.get(f"{self.API_URL}/blocks/{request.height}")
         return Parse(json_response, GetBlockByHeightResponse())
 
     def GetLatestValidatorSet(
-        self, request: GetLatestValidatorSetRequest
+        self,
+        request: GetLatestValidatorSetRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> GetLatestValidatorSetResponse:
         """
         GetLatestValidatorSet queries latest validator-set.
 
         :param request: GetLatestValidatorSetRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: GetLatestValidatorSetResponse
         """
         json_response = self._rest_api.get(
@@ -113,12 +141,16 @@ class CosmosBaseTendermintRestClient(CosmosBaseTendermint):
         return Parse(json_response, GetLatestValidatorSetResponse())
 
     def GetValidatorSetByHeight(
-        self, request: GetValidatorSetByHeightRequest
+        self,
+        request: GetValidatorSetByHeightRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
     ) -> GetValidatorSetByHeightResponse:
         """
         GetValidatorSetByHeight queries validator-set at a given height.
 
         :param request: GetValidatorSetByHeightRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: GetValidatorSetByHeightResponse
         """
         json_response = self._rest_api.get(

--- a/cosmpy/tx/interface.py
+++ b/cosmpy/tx/interface.py
@@ -20,6 +20,7 @@
 """Interface for the Tx functionality of CosmosSDK."""
 
 from abc import ABC, abstractmethod
+from typing import Optional, Tuple
 
 import cosmpy.protos.cosmos.tx.v1beta1.service_pb2 as svc
 
@@ -28,37 +29,57 @@ class TxInterface(ABC):
     """Tx abstract class."""
 
     @abstractmethod
-    def Simulate(self, request: svc.SimulateRequest) -> svc.SimulateResponse:
+    def Simulate(
+        self,
+        request: svc.SimulateRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> svc.SimulateResponse:
         """
         Simulate executing a transaction to estimate gas usage.
 
         :param request: SimulateRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: SimulateResponse
         """
 
     @abstractmethod
-    def GetTx(self, request: svc.GetTxRequest) -> svc.GetTxResponse:
+    def GetTx(
+        self,
+        request: svc.GetTxRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> svc.GetTxResponse:
         """
         GetTx fetches a tx by hash.
 
         :param request: GetTxRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: GetTxResponse
         """
 
     @abstractmethod
-    def BroadcastTx(self, request: svc.BroadcastTxRequest) -> svc.BroadcastTxResponse:
+    def BroadcastTx(
+        self,
+        request: svc.BroadcastTxRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> svc.BroadcastTxResponse:
         """
         BroadcastTx broadcast transaction.
 
         :param request: BroadcastTxRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: BroadcastTxResponse
         """
 
     @abstractmethod
-    def GetTxsEvent(self, request: svc.GetTxsEventRequest) -> svc.GetTxsEventResponse:
+    def GetTxsEvent(
+        self,
+        request: svc.GetTxsEventRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> svc.GetTxsEventResponse:
         """
         GetTxsEvent fetches txs by event.
 
         :param request: GetTxsEventRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: GetTxsEventResponse
         """

--- a/cosmpy/tx/rest_client.py
+++ b/cosmpy/tx/rest_client.py
@@ -21,7 +21,7 @@
 
 import base64
 import json
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional, Tuple
 
 from google.protobuf.json_format import Parse, ParseDict
 
@@ -64,11 +64,16 @@ class TxRestClient(TxInterface):
         """
         self.rest_client = rest_client
 
-    def Simulate(self, request: SimulateRequest) -> SimulateResponse:
+    def Simulate(
+        self,
+        request: SimulateRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> SimulateResponse:
         """
         Simulate executing a transaction to estimate gas usage.
 
         :param request: SimulateRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: SimulateResponse
         """
         response = self.rest_client.post(
@@ -77,11 +82,14 @@ class TxRestClient(TxInterface):
         )
         return Parse(response, SimulateResponse())
 
-    def GetTx(self, request: GetTxRequest) -> GetTxResponse:
+    def GetTx(
+        self, request: GetTxRequest, metadata: Optional[Tuple[Tuple[str, str]]] = None
+    ) -> GetTxResponse:
         """
         GetTx fetches a tx by hash.
 
         :param request: GetTxRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: GetTxResponse
         """
         response = self.rest_client.get(f"{self.API_URL}/txs/{request.hash}")
@@ -93,21 +101,31 @@ class TxRestClient(TxInterface):
 
         return ParseDict(dict_response, GetTxResponse())
 
-    def BroadcastTx(self, request: BroadcastTxRequest) -> BroadcastTxResponse:
+    def BroadcastTx(
+        self,
+        request: BroadcastTxRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> BroadcastTxResponse:
         """
         BroadcastTx broadcast transaction.
 
         :param request: BroadcastTxRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: BroadcastTxResponse
         """
         response = self.rest_client.post(f"{self.API_URL}/txs", request)
         return Parse(response, BroadcastTxResponse())
 
-    def GetTxsEvent(self, request: GetTxsEventRequest) -> GetTxsEventResponse:
+    def GetTxsEvent(
+        self,
+        request: GetTxsEventRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> GetTxsEventResponse:
         """
         GetTxsEvent fetches txs by event.
 
         :param request: GetTxsEventRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
         :return: GetTxsEventResponse
         """
         response = self.rest_client.get(f"{self.API_URL}/txs", request)

--- a/cosmpy/upgrade/interface.py
+++ b/cosmpy/upgrade/interface.py
@@ -19,6 +19,7 @@
 """Interface for the Cosmos Upgrade functionality of CosmosSDK."""
 
 from abc import ABC, abstractmethod
+from typing import Optional, Tuple
 
 from cosmpy.protos.cosmos.upgrade.v1beta1.query_pb2 import (
     QueryAppliedPlanRequest,
@@ -32,19 +33,31 @@ class CosmosUpgrade(ABC):
     """Cosmos Upgrade abstract class."""
 
     @abstractmethod
-    def CurrentPlan(self, request: QueryCurrentPlanRequest) -> QueryCurrentPlanResponse:
+    def CurrentPlan(
+        self,
+        request: QueryCurrentPlanRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryCurrentPlanResponse:
         """
         CurrentPlan queries the current upgrade plan.
 
         :param request: QueryCurrentPlanRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: QueryCurrentPlanResponse
         """
 
     @abstractmethod
-    def AppliedPlan(self, request: QueryAppliedPlanRequest) -> QueryAppliedPlanResponse:
+    def AppliedPlan(
+        self,
+        request: QueryAppliedPlanRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryAppliedPlanResponse:
         """
         AppliedPlan queries a previously applied upgrade plan by its name.
 
         :param request: QueryAppliedPlanRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: QueryAppliedPlanResponse
         """

--- a/cosmpy/upgrade/rest_client.py
+++ b/cosmpy/upgrade/rest_client.py
@@ -17,6 +17,8 @@
 #
 # ------------------------------------------------------------------------------
 """Implementation of IBC Applications Transfer  interface using REST."""
+from typing import Optional, Tuple
+
 from google.protobuf.json_format import Parse
 
 from cosmpy.common.rest_client import RestClient
@@ -42,11 +44,17 @@ class CosmosUpgradeRestClient(CosmosUpgrade):
         """
         self._rest_api = rest_api
 
-    def CurrentPlan(self, request: QueryCurrentPlanRequest) -> QueryCurrentPlanResponse:
+    def CurrentPlan(
+        self,
+        request: QueryCurrentPlanRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryCurrentPlanResponse:
         """
         CurrentPlan queries the current upgrade plan.
 
         :param request: QueryCurrentPlanRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: QueryCurrentPlanResponse
         """
         json_response = self._rest_api.get(
@@ -54,11 +62,17 @@ class CosmosUpgradeRestClient(CosmosUpgrade):
         )
         return Parse(json_response, QueryCurrentPlanResponse())
 
-    def AppliedPlan(self, request: QueryAppliedPlanRequest) -> QueryAppliedPlanResponse:
+    def AppliedPlan(
+        self,
+        request: QueryAppliedPlanRequest,
+        metadata: Optional[Tuple[Tuple[str, str]]] = None,
+    ) -> QueryAppliedPlanResponse:
         """
         AppliedPlan queries a previously applied upgrade plan by its name.
 
         :param request: QueryAppliedPlanRequest
+        :param metadata: The metadata for the call or None. metadata are additional headers
+
         :return: QueryAppliedPlanResponse
         """
         json_response = self._rest_api.get(

--- a/tests/unit/test_common/test_rest_client.py
+++ b/tests/unit/test_common/test_rest_client.py
@@ -64,7 +64,7 @@ class QueryRestClientTestCase(TestCase):
         messageToDict_mock.assert_called_once_with(request)
 
         expected_url = f"{rest_address}{request_url_path}?a=1&b=something&b=else&some_dict.x=1&some_dict.y=2"
-        session_mock.return_value.get.assert_called_once_with(url=expected_url)
+        session_mock.return_value.get.assert_called_once_with(url=expected_url, headers={})
 
     @patch("requests.session", spec=Session)
     @patch("cosmpy.common.rest_client.MessageToDict")


### PR DESCRIPTION
## Proposed changes

Add the possibility to query at a given block in the past
This feature is already avalable with gRPC but need to modify the interface for REST

This patch add the `metadata` attribute to the REST interface.
Call at height can be made using
```python
metadata = (("x-cosmos-block-height", "123456"),)
bank.Balance(QueryBalanceRequest(address="account", denom="denom"), 
             metadata=metadata)
```

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to stop working as expected)
- [ ] Something else (e.g. tests, scripts, example, deployment, infrastructure, ...)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/fetchai/cosmpy/blob/main/CONTRIBUTING.md) document.
- [x] I have based my branch, and I am making a pull request against, the `main` branch.
- [x] Checks and tests pass locally.

### If applicable

- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have checked that code coverage does not decrease.
- [x] I have added/updated the documentations.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc.
