### PR TITLE
Coins parsing fix to support ibc denoms

### DIFF
--- a/cosmpy/aerial/client/__init__.py
+++ b/cosmpy/aerial/client/__init__.py
@@ -433,7 +433,6 @@ class LedgerClient:
             req, self.staking.DelegatorDelegations, per_page_limit=1
         ):
             for item in resp.delegation_responses:
-
                 req = QueryDelegationRewardsRequest(
                     delegator_address=str(address),
                     validator_address=str(item.delegation.validator_address),

--- a/cosmpy/aerial/client/utils.py
+++ b/cosmpy/aerial/client/utils.py
@@ -52,7 +52,6 @@ def prepare_and_broadcast_basic_transaction(
         # simply build the fee from the provided gas limit
         fee = client.estimate_fee_from_gas(gas_limit)
     else:
-
         # we need to build up a representative transaction so that we can accurately simulate it
         tx.seal(
             SigningCfg.direct(sender.public_key(), account.sequence),

--- a/cosmpy/aerial/coins.py
+++ b/cosmpy/aerial/coins.py
@@ -40,7 +40,7 @@ def parse_coins(value: str) -> List[Coin]:
         if part == "":
             continue
 
-        match = re.match(r"(\d+)(\w+)", part)
+        match = re.match(r"^(\d+)(.+)$", part)
         if match is None:
             raise RuntimeError(f"Unable to parse value {part}")
 

--- a/cosmpy/aerial/contract/__init__.py
+++ b/cosmpy/aerial/contract/__init__.py
@@ -466,7 +466,7 @@ class LedgerContract(UserString):
         if self._schema is None:
             return
 
-        for (msg_type, schema) in self._schema.items():
+        for msg_type, schema in self._schema.items():
             if "instantiate" in msg_type:
                 self._instantiate_schema = schema
             elif "query" in msg_type:

--- a/tests/unit/test_aerial/coins_test.py
+++ b/tests/unit/test_aerial/coins_test.py
@@ -31,11 +31,24 @@ from cosmpy.protos.cosmos.base.v1beta1.coin_pb2 import Coin
         ("          ", []),
         ("50000atestfet", [Coin(amount="50000", denom="atestfet")]),
         (
-            "50000atestfet,     200foobar",
-            [
-                Coin(amount="50000", denom="atestfet"),
-                Coin(amount="200", denom="foobar"),
-            ],
+                "50000atestfet,     200foobar",
+                [
+                    Coin(amount="50000", denom="atestfet"),
+                    Coin(amount="200", denom="foobar"),
+                ],
+        ),
+        (
+                "500ibc/0471F1C4E7AFD3F07702BEF6DC365268D64570F7C1FDC98EA6098DD6DE59817B",
+                [
+                    Coin(amount="500", denom="ibc/0471F1C4E7AFD3F07702BEF6DC365268D64570F7C1FDC98EA6098DD6DE59817B")
+                ]
+        ),
+        (
+                "500ibc/0471F1C4E7AFD3F07702BEF6DC365268D64570F7C1FDC98EA6098DD6DE59817B, 50000atestfet",
+                [
+                    Coin(amount="500", denom="ibc/0471F1C4E7AFD3F07702BEF6DC365268D64570F7C1FDC98EA6098DD6DE59817B"),
+                    Coin(amount="50000", denom="atestfet"),
+                ]
         ),
     ],
 )

--- a/tests/unit/test_aerial/coins_test.py
+++ b/tests/unit/test_aerial/coins_test.py
@@ -31,24 +31,30 @@ from cosmpy.protos.cosmos.base.v1beta1.coin_pb2 import Coin
         ("          ", []),
         ("50000atestfet", [Coin(amount="50000", denom="atestfet")]),
         (
-                "50000atestfet,     200foobar",
-                [
-                    Coin(amount="50000", denom="atestfet"),
-                    Coin(amount="200", denom="foobar"),
-                ],
+            "50000atestfet,     200foobar",
+            [
+                Coin(amount="50000", denom="atestfet"),
+                Coin(amount="200", denom="foobar"),
+            ],
         ),
         (
-                "500ibc/0471F1C4E7AFD3F07702BEF6DC365268D64570F7C1FDC98EA6098DD6DE59817B",
-                [
-                    Coin(amount="500", denom="ibc/0471F1C4E7AFD3F07702BEF6DC365268D64570F7C1FDC98EA6098DD6DE59817B")
-                ]
+            "500ibc/0471F1C4E7AFD3F07702BEF6DC365268D64570F7C1FDC98EA6098DD6DE59817B",
+            [
+                Coin(
+                    amount="500",
+                    denom="ibc/0471F1C4E7AFD3F07702BEF6DC365268D64570F7C1FDC98EA6098DD6DE59817B",
+                )
+            ],
         ),
         (
-                "500ibc/0471F1C4E7AFD3F07702BEF6DC365268D64570F7C1FDC98EA6098DD6DE59817B, 50000atestfet",
-                [
-                    Coin(amount="500", denom="ibc/0471F1C4E7AFD3F07702BEF6DC365268D64570F7C1FDC98EA6098DD6DE59817B"),
-                    Coin(amount="50000", denom="atestfet"),
-                ]
+            "500ibc/0471F1C4E7AFD3F07702BEF6DC365268D64570F7C1FDC98EA6098DD6DE59817B, 50000atestfet",
+            [
+                Coin(
+                    amount="500",
+                    denom="ibc/0471F1C4E7AFD3F07702BEF6DC365268D64570F7C1FDC98EA6098DD6DE59817B",
+                ),
+                Coin(amount="50000", denom="atestfet"),
+            ],
         ),
     ],
 )


### PR DESCRIPTION
## Proposed changes

Original PR by [george-aj](https://github.com/george-aj) #375

The current `parse_coins` regex is not able to handle ibc denoms. For any network that supports paying fees in the non native token this results in the denom being just `ibc` 

The proposed change modifies the regex slightly to account for ibc denoms.
## Issues

Links to any issues resolved.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to stop working as expected)
- [ ] Something else (e.g. tests, scripts, example, deployment, infrastructure, ...)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](https://github.com/fetchai/cosmpy/blob/main/CONTRIBUTING.md) document.
- [ ] I have based my branch, and I am making a pull request against, the `main` branch.
- [ ] Checks and tests pass locally.

### If applicable

- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have checked that code coverage does not decrease.
- [ ] I have added/updated the documentations.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc.
