### PR TITLE
Add support for URLs with paths

### DIFF
--- a/cosmpy/aerial/urls.py
+++ b/cosmpy/aerial/urls.py
@@ -45,6 +45,7 @@ class ParsedUrl:
     secure: bool
     hostname: str
     port: int
+    path: str
 
     @property
     def host_and_port(self) -> str:
@@ -71,6 +72,8 @@ class ParsedUrl:
         url = f"{prefix}://{self.hostname}"
         if self.port != default_port:
             url += f":{self.port}"
+        if self.path:
+            url += self.path
         return url
 
 
@@ -103,5 +106,6 @@ def parse_url(url: str) -> ParsedUrl:
 
     hostname = str(result.hostname)
     port = default_port if result.port is None else int(result.port)
+    path = result.path if result.path else ""
 
-    return ParsedUrl(protocol=protocol, secure=secure, hostname=hostname, port=port)
+    return ParsedUrl(protocol=protocol, secure=secure, hostname=hostname, port=port, path=path)


### PR DESCRIPTION
## Proposed Changes

Adds support for REST urls with paths. Currently the assumption is a url will end with the port and/or dns, for example, `rest+https://cosmoshub-api.lavenderfive.com:443`. This PR adds support for the following: `rest+https://rpc.cosmos.directory:443/cosmoshub`.

## Linked Issues

NA

## Types of changes

_What type of change does this pull request make (put an `x` in the boxes that apply)?_

- [ ] Bug fix (non-breaking change that fixes an issue).
- [x] New feature added (non-breaking change that adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to stop working as expected).
- [ ] Documentation update.
- [ ] Something else (e.g., tests, scripts, example, deployment, infrastructure).

## Checklist

_Put an `x` in the boxes that apply:_

- [x] I have read the [CONTRIBUTING](https://github.com/fetchai/cosmpy/blob/main/CONTRIBUTING.md) guide
- [ ] Checks and tests pass locally

### If applicable

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease
- [ ] I have added/updated the documentation

## Further comments

_[if this is a relatively large or complex change, kick off a discussion by explaining why you chose the solution you did, what alternatives you considered, etc...]_
