### PR TITLE
Fix Spelling Errors in `stake-optimizer.md` and `aerial_stake_optimizer.py`

### DIFF
--- a/docs/stake-optimizer.md
+++ b/docs/stake-optimizer.md
@@ -40,12 +40,12 @@ validators_stake = [int(validator.tokens) for validator in resp.validators if va
 total_stake = sum(validators_stake)
 
 # For every bonded validator, we print commission and percentage of total stake
-print("MONIKER      COMISSION   % of TOTAL STAKE")
+print("MONIKER      COMMISSION   % of TOTAL STAKE")
 for validator in resp.validators:
     if validator.status == 3:
         moniker = validator.description.moniker
-        comission = int(validator.commission.commission_rates.rate)/1e18*100
-        print(moniker[:10]," ", comission,"%     ", round(int(validator.tokens)/total_stake*100,3),"%")
+        commission = int(validator.commission.commission_rates.rate)/1e18*100
+        print(moniker[:10]," ", commission,"%     ", round(int(validator.tokens)/total_stake*100,3),"%")
 ```
 
 After running the code above, you will observe each validator commission rate and its percentage delegated of the total stake. The most important parameter to observe in each validator is the commission it will take from the rewards. We will always select a validator with the lower commission as long as it has a reasonable stake compared with the total stake. In this case, at the moment the code was run, all validators had the same commission, therefore, we simply selected the validator with the highest stake, which was validator0. Feel free to select the most convenient validator when you run the code above. We will save the variables `commission` and the fraction of our `initial_stake` to the total stake to use them later on.
@@ -60,7 +60,7 @@ selected_validator = "validator0"
 validator = [v for v in validators if v.moniker == selected_validator][0]
 query_validator = [v for v in resp.validators if v.description.moniker == selected_validator][0]
 
-# Set the comission %
+# Set the commission %
 commission = int(query_validator.commission.commission_rates.rate)/1e18
 
 # Set percentage delegated of total stake

--- a/examples/aerial_stake_optimizer.py
+++ b/examples/aerial_stake_optimizer.py
@@ -78,7 +78,7 @@ def main():
     total_stake = sum(validators_stake)
 
     # Get validators commissions
-    validators_comission = [
+    validators_commission = [
         int(validator.commission.commission_rates.rate)
         for validator in resp.validators
         if validator.status == 3
@@ -90,10 +90,10 @@ def main():
     # Choose a threshold for a validators minimum percentage of total stake delegated
     stake_threshold = 0.10
 
-    for _i in range(len(validators_comission)):
+    for _i in range(len(validators_commission)):
 
         # Choose validator with lower commission
-        validator_index = validators_comission.index(min(validators_comission))
+        validator_index = validators_commission.index(min(validators_commission))
 
         # Verify that it meets the minimum % threshold
         validator_stake_pct = validators_stake[validator_index] / total_stake
@@ -104,11 +104,11 @@ def main():
             break
 
         # We omit this validator by setting his commssion to infinity
-        validators_comission[validator_index] = float("inf")
+        validators_commission[validator_index] = float("inf")
 
     if validator == "not_selected":
-        # Restart validators_comission list with original values
-        validators_comission = [
+        # Restart validators_commission list with original values
+        validators_commission = [
             int(validator.commission.commission_rates.rate)
             for validator in resp.validators
             if validator.status == 3
@@ -117,7 +117,7 @@ def main():
         print("No validator meets the minimum stake threshold requirement")
 
         # Proceed to select the validator with the lowest commission
-        validator_index = validators_comission.index(min(validators_comission))
+        validator_index = validators_commission.index(min(validators_commission))
         validator = validators[validator_index]
 
     # Query validator commission


### PR DESCRIPTION
## Proposed Changes  
- Fixed misspelled variable names such as `comission` → `commission`, `validators_comission` → `validators_commission`, and `commssion` → `commission` in `aerial_stake_optimizer.py`.  
- Updated occurrences of `comission` → `commission` in `stake-optimizer.md`.  
- Ensured consistency in terminology related to validator commissions and stake thresholds.

## Types of Changes  
- [x] Bug fix (non-breaking change that fixes an issue).  
- [ ] New feature added (non-breaking change that adds functionality).  
- [ ] Breaking change (fix or feature that would cause existing functionality to stop working as expected).  
- [ ] Documentation update.  
- [ ] Other (tests, scripts, example, deployment, infrastructure).

## Checklist  
- [x] I have read the [CONTRIBUTING](https://github.com/fetchai/cosmpy/blob/main/CONTRIBUTING.md) guide.  
- [x] Checks and tests pass locally.  
- [x] Updated documentation where applicable.