### PR TITLE
feat: add asyncio-native AsyncLedgerClient (gRPC, no thread wrapping)

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -342,4 +342,16 @@ setuptools
 AsyncLedgerClient
 AsyncSubmittedTx
 Async
+async
 AsyncGasStrategy
+AsyncSimulationGasStrategy
+aio
+Asyncio
+asyncio
+awaitables
+gRPC
+grpc's
+coroutine
+aenter
+traceback
+LedgerClientBase

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -353,5 +353,6 @@ gRPC
 grpc's
 coroutine
 aenter
+aexit
 traceback
 LedgerClientBase

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -339,3 +339,7 @@ ConsensusRestClient
 CosmosSDK
 NodeInfo
 setuptools
+AsyncLedgerClient
+AsyncSubmittedTx
+Async
+AsyncGasStrategy

--- a/cosmpy/aerial/client/aio.py
+++ b/cosmpy/aerial/client/aio.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # ------------------------------------------------------------------------------
 #
-#   Copyright 2018-2021 Fetch.AI Limited
+#   Copyright 2018-2022 Fetch.AI Limited
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -17,17 +17,34 @@
 #
 # ------------------------------------------------------------------------------
 
-"""Client functionality."""
+"""Asyncio-native client functionality (gRPC endpoints only).
+
+``AsyncLedgerClient`` mirrors ``LedgerClient`` method for method, but performs
+all network I/O on grpc's native asyncio channel (``grpc.aio``) — no worker
+threads involved. It reuses the same generated protobuf stubs as the sync
+client; the stubs return awaitables when constructed over an aio channel.
+
+Note: instantiate the client from within a running event loop (i.e. inside the
+coroutine passed to ``asyncio.run``) — the underlying grpc.aio channel binds to
+the running loop when it is created.
+
+Usage:
+
+.. code-block:: python
+
+    async with AsyncLedgerClient(NetworkConfig.fetchai_mainnet()) as client:
+        balance = await client.query_bank_balance(address)
+"""
+import asyncio
 import json
-import time
 from datetime import datetime, timedelta
-from typing import Any, List, Optional, Tuple
+from typing import Any, Callable, List, Optional, Tuple, Union
 
 import grpc
+from grpc import aio
 
 from cosmpy.aerial.client.bank import create_bank_send_msg
-from cosmpy.aerial.client.base import (  # noqa: F401 # pylint: disable=unused-import
-    COSMOS_SDK_DEC_COIN_PRECISION,
+from cosmpy.aerial.client.base import (
     DEFAULT_QUERY_INTERVAL_SECS,
     DEFAULT_QUERY_TIMEOUT_SECS,
     LedgerClientBase,
@@ -41,33 +58,23 @@ from cosmpy.aerial.client.staking import (
     create_redelegate_msg,
     create_undelegate_msg,
 )
-from cosmpy.aerial.client.utils import (
-    TxFee,
-    get_paginated,
-    prepare_and_broadcast_basic_transaction,
-)
+from cosmpy.aerial.client.utils import DEFAULT_PER_PAGE_LIMIT
 from cosmpy.aerial.coins import Coin
 from cosmpy.aerial.config import NetworkConfig
 from cosmpy.aerial.exceptions import NotFoundError, QueryTimeoutError
-from cosmpy.aerial.gas import GasStrategy, SimulationGasStrategy
-from cosmpy.aerial.tx import Transaction
-from cosmpy.aerial.tx_helpers import SubmittedTx, TxResponse
+from cosmpy.aerial.gas import AsyncGasStrategy, AsyncSimulationGasStrategy, GasStrategy
+from cosmpy.aerial.tx import SigningCfg, Transaction, TxFee
+from cosmpy.aerial.tx_helpers import AsyncSubmittedTx, TxResponse
 from cosmpy.aerial.types import Account, Block, NodeInfo
 from cosmpy.aerial.urls import Protocol, parse_url
 from cosmpy.aerial.wallet import Wallet
-from cosmpy.auth.rest_client import AuthRestClient
-from cosmpy.bank.rest_client import BankRestClient
-from cosmpy.common.rest_client import RestClient
-from cosmpy.consensus.rest_client import ConsensusRestClient
-from cosmpy.cosmwasm.rest_client import CosmWasmRestClient
 from cosmpy.crypto.address import Address
-from cosmpy.distribution.rest_client import DistributionRestClient
-from cosmpy.params.rest_client import ParamsRestClient
 from cosmpy.protos.cosmos.auth.v1beta1.query_pb2 import QueryAccountRequest
 from cosmpy.protos.cosmos.bank.v1beta1.query_pb2 import (
     QueryAllBalancesRequest,
     QueryBalanceRequest,
 )
+from cosmpy.protos.cosmos.base.query.v1beta1.pagination_pb2 import PageRequest
 from cosmpy.protos.cosmos.base.tendermint.v1beta1.query_pb2 import (
     GetBlockByHeightRequest,
     GetLatestBlockRequest,
@@ -88,15 +95,10 @@ from cosmpy.protos.cosmos.tx.v1beta1.service_pb2 import (
     GetTxRequest,
     SimulateRequest,
 )
-from cosmpy.staking.rest_client import StakingRestClient
-from cosmpy.tendermint.rest_client import (
-    CosmosBaseTendermintRestClient as TendermintRestClient,
-)
-from cosmpy.tx.rest_client import TxRestClient
 
 
-class LedgerClient(LedgerClientBase):
-    """Ledger client."""
+class AsyncLedgerClient(LedgerClientBase):
+    """Asyncio-native ledger client (gRPC endpoints only)."""
 
     def __init__(
         self,
@@ -104,40 +106,58 @@ class LedgerClient(LedgerClientBase):
         query_interval_secs: int = DEFAULT_QUERY_INTERVAL_SECS,
         query_timeout_secs: int = DEFAULT_QUERY_TIMEOUT_SECS,
     ):
-        """Init ledger client.
+        """Init async ledger client.
 
         :param cfg: Network configurations
         :param query_interval_secs: int. optional interval int seconds
         :param query_timeout_secs: int. optional interval int seconds
+        :raises RuntimeError: Network config url is not a gRPC endpoint
         """
         super().__init__(cfg, query_interval_secs, query_timeout_secs)
-        self._gas_strategy: GasStrategy = SimulationGasStrategy(self)
+        self._gas_strategy: Union[
+            GasStrategy, AsyncGasStrategy
+        ] = AsyncSimulationGasStrategy(self)
 
         parsed_url = parse_url(cfg.url)
 
-        if parsed_url.protocol == Protocol.GRPC:
-            if parsed_url.secure:
-                credentials = self._create_ssl_credentials()
-                grpc_client = grpc.secure_channel(parsed_url.host_and_port, credentials)
-            else:
-                grpc_client = grpc.insecure_channel(parsed_url.host_and_port)
+        if parsed_url.protocol != Protocol.GRPC:
+            raise RuntimeError(
+                "AsyncLedgerClient supports gRPC endpoints only; "
+                f"got {cfg.url!r}. Use LedgerClient for REST endpoints."
+            )
 
-            self._init_grpc_stubs(grpc_client)
+        if parsed_url.secure:
+            credentials = self._create_ssl_credentials()
+            self._grpc_channel = aio.secure_channel(
+                parsed_url.host_and_port, credentials
+            )
         else:
-            rest_client = RestClient(parsed_url.rest_url)
+            self._grpc_channel = aio.insecure_channel(parsed_url.host_and_port)
 
-            self.wasm = CosmWasmRestClient(rest_client)  # type: ignore
-            self.auth = AuthRestClient(rest_client)  # type: ignore
-            self.txs = TxRestClient(rest_client)  # type: ignore
-            self.bank = BankRestClient(rest_client)  # type: ignore
-            self.staking = StakingRestClient(rest_client)  # type: ignore
-            self.distribution = DistributionRestClient(rest_client)  # type: ignore
-            self.params = ParamsRestClient(rest_client)  # type: ignore
-            self.consensus = ConsensusRestClient(rest_client)  # type: ignore
-            self.tendermint = TendermintRestClient(rest_client)  # type: ignore
+        self._init_grpc_stubs(self._grpc_channel)
+
+    async def close(self):
+        """Close the underlying gRPC channel."""
+        await self._grpc_channel.close()
+
+    async def __aenter__(self) -> "AsyncLedgerClient":
+        """Enter the async context.
+
+        :return: this client
+        """
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        """Exit the async context, closing the gRPC channel.
+
+        :param exc_type: exception type
+        :param exc_value: exception value
+        :param traceback: exception traceback
+        """
+        await self.close()
 
     @property
-    def gas_strategy(self) -> GasStrategy:
+    def gas_strategy(self) -> Union[GasStrategy, AsyncGasStrategy]:
         """Get gas strategy.
 
         :return: gas strategy
@@ -145,27 +165,29 @@ class LedgerClient(LedgerClientBase):
         return self._gas_strategy
 
     @gas_strategy.setter
-    def gas_strategy(self, strategy: GasStrategy):
+    def gas_strategy(self, strategy: Union[GasStrategy, AsyncGasStrategy]):
         """Set gas strategy.
 
         :param strategy: strategy
-        :raises RuntimeError: Invalid strategy must implement GasStrategy interface
+        :raises RuntimeError: Invalid strategy must implement GasStrategy or AsyncGasStrategy interface
         """
-        if not isinstance(strategy, GasStrategy):
-            raise RuntimeError("Invalid strategy must implement GasStrategy interface")
+        if not isinstance(strategy, (GasStrategy, AsyncGasStrategy)):
+            raise RuntimeError(
+                "Invalid strategy must implement GasStrategy or AsyncGasStrategy interface"
+            )
         self._gas_strategy = strategy
 
-    def query_account(self, address: Address) -> Account:
+    async def query_account(self, address: Address) -> Account:
         """Query account.
 
         :param address: address
         :return: account details
         """
         request = QueryAccountRequest(address=str(address))
-        response = self.auth.Account(request)
+        response = await self.auth.Account(request)
         return self._parse_account(response, address)
 
-    def query_params(self, subspace: str, key: str) -> Any:
+    async def query_params(self, subspace: str, key: str) -> Any:
         """Query Prams.
 
         :param subspace: subspace
@@ -173,29 +195,31 @@ class LedgerClient(LedgerClientBase):
         :return: Query params
         """
         req = QueryParamsRequest(subspace=subspace, key=key)
-        resp = self.params.Params(req)
+        resp = await self.params.Params(req)
         return json.loads(resp.param.value)
 
-    def query_node_info(self) -> NodeInfo:
+    async def query_node_info(self) -> NodeInfo:
         """
         Query basic Tendermint / node information (moniker, chain-id, version, etc.).
 
         :return: NodeInfo.
         """
         request = GetNodeInfoRequest()
-        response = self.tendermint.GetNodeInfo(request)
+        response = await self.tendermint.GetNodeInfo(request)
         return self._parse_node_info(response)
 
-    def query_consensus_params(self) -> Any:
+    async def query_consensus_params(self) -> Any:
         """Query consensus params.
 
         :return: Query consensus params
         """
         req = QueryParamsRequest()
-        resp = self.consensus.Params(req)
+        resp = await self.consensus.Params(req)
         return resp
 
-    def query_bank_balance(self, address: Address, denom: Optional[str] = None) -> int:
+    async def query_bank_balance(
+        self, address: Address, denom: Optional[str] = None
+    ) -> int:
         """Query bank balance.
 
         :param address: address
@@ -209,20 +233,20 @@ class LedgerClient(LedgerClientBase):
             denom=denom,
         )
 
-        resp = self.bank.Balance(req)
+        resp = await self.bank.Balance(req)
         return self._parse_bank_balance(resp, denom)
 
-    def query_bank_all_balances(self, address: Address) -> List[Coin]:
+    async def query_bank_all_balances(self, address: Address) -> List[Coin]:
         """Query bank all balances.
 
         :param address: address
         :return: bank all balances
         """
         req = QueryAllBalancesRequest(address=str(address))
-        resp = self.bank.AllBalances(req)
+        resp = await self.bank.AllBalances(req)
         return self._parse_bank_all_balances(resp)
 
-    def send_tokens(
+    async def send_tokens(
         self,
         destination: Address,
         amount: int,
@@ -231,7 +255,7 @@ class LedgerClient(LedgerClientBase):
         memo: Optional[str] = None,
         fee: Optional[TxFee] = None,
         timeout_height: Optional[int] = None,
-    ) -> SubmittedTx:
+    ) -> AsyncSubmittedTx:
         """Send tokens.
 
         :param destination: destination address
@@ -249,7 +273,7 @@ class LedgerClient(LedgerClientBase):
             create_bank_send_msg(sender.address(), destination, amount, denom)
         )
 
-        return prepare_and_broadcast_basic_transaction(
+        return await prepare_and_broadcast_basic_transaction(
             self,
             tx,
             sender,
@@ -258,7 +282,7 @@ class LedgerClient(LedgerClientBase):
             timeout_height=timeout_height,
         )
 
-    def query_validators(
+    async def query_validators(
         self, status: Optional[ValidatorStatus] = None
     ) -> List[Validator]:
         """Query validators.
@@ -272,10 +296,10 @@ class LedgerClient(LedgerClientBase):
         if filtered_status != ValidatorStatus.UNSPECIFIED:
             req.status = filtered_status.value
 
-        resp = self.staking.Validators(req)
+        resp = await self.staking.Validators(req)
         return self._parse_validators(resp)
 
-    def query_staking_summary(self, address: Address) -> StakingSummary:
+    async def query_staking_summary(self, address: Address) -> StakingSummary:
         """Query staking summary.
 
         :param address: address
@@ -285,7 +309,7 @@ class LedgerClient(LedgerClientBase):
 
         req = QueryDelegatorDelegationsRequest(delegator_addr=str(address))
 
-        for resp in get_paginated(
+        for resp in await get_paginated(
             req, self.staking.DelegatorDelegations, per_page_limit=1
         ):
             for item in resp.delegation_responses:
@@ -293,21 +317,23 @@ class LedgerClient(LedgerClientBase):
                     delegator_address=str(address),
                     validator_address=str(item.delegation.validator_address),
                 )
-                rewards_resp = self.distribution.DelegationRewards(req)
+                rewards_resp = await self.distribution.DelegationRewards(req)
 
                 current_positions.append(
                     self._parse_staking_position(item, rewards_resp)
                 )
 
         req = QueryDelegatorUnbondingDelegationsRequest(delegator_addr=str(address))
-        unbonding_pages = get_paginated(req, self.staking.DelegatorUnbondingDelegations)
+        unbonding_pages = await get_paginated(
+            req, self.staking.DelegatorUnbondingDelegations
+        )
 
         return StakingSummary(
             current_positions=current_positions,
             unbonding_positions=self._build_unbonding_positions(unbonding_pages),
         )
 
-    def delegate_tokens(
+    async def delegate_tokens(
         self,
         validator: Address,
         amount: int,
@@ -315,7 +341,7 @@ class LedgerClient(LedgerClientBase):
         memo: Optional[str] = None,
         fee: Optional[TxFee] = None,
         timeout_height: Optional[int] = None,
-    ) -> SubmittedTx:
+    ) -> AsyncSubmittedTx:
         """Delegate tokens.
 
         :param validator: validator address
@@ -336,7 +362,7 @@ class LedgerClient(LedgerClientBase):
             )
         )
 
-        return prepare_and_broadcast_basic_transaction(
+        return await prepare_and_broadcast_basic_transaction(
             self,
             tx,
             sender,
@@ -345,7 +371,7 @@ class LedgerClient(LedgerClientBase):
             timeout_height=timeout_height,
         )
 
-    def redelegate_tokens(
+    async def redelegate_tokens(
         self,
         current_validator: Address,
         next_validator: Address,
@@ -354,7 +380,7 @@ class LedgerClient(LedgerClientBase):
         memo: Optional[str] = None,
         fee: Optional[TxFee] = None,
         timeout_height: Optional[int] = None,
-    ) -> SubmittedTx:
+    ) -> AsyncSubmittedTx:
         """Redelegate tokens.
 
         :param current_validator: current validator address
@@ -377,7 +403,7 @@ class LedgerClient(LedgerClientBase):
             )
         )
 
-        return prepare_and_broadcast_basic_transaction(
+        return await prepare_and_broadcast_basic_transaction(
             self,
             tx,
             sender,
@@ -386,7 +412,7 @@ class LedgerClient(LedgerClientBase):
             timeout_height=timeout_height,
         )
 
-    def undelegate_tokens(
+    async def undelegate_tokens(
         self,
         validator: Address,
         amount: int,
@@ -394,7 +420,7 @@ class LedgerClient(LedgerClientBase):
         memo: Optional[str] = None,
         fee: Optional[TxFee] = None,
         timeout_height: Optional[int] = None,
-    ) -> SubmittedTx:
+    ) -> AsyncSubmittedTx:
         """Undelegate tokens.
 
         :param validator: validator
@@ -415,7 +441,7 @@ class LedgerClient(LedgerClientBase):
             )
         )
 
-        return prepare_and_broadcast_basic_transaction(
+        return await prepare_and_broadcast_basic_transaction(
             self,
             tx,
             sender,
@@ -424,14 +450,14 @@ class LedgerClient(LedgerClientBase):
             timeout_height=timeout_height,
         )
 
-    def claim_rewards(
+    async def claim_rewards(
         self,
         validator: Address,
         sender: Wallet,
         memo: Optional[str] = None,
         fee: Optional[TxFee] = None,
         timeout_height: Optional[int] = None,
-    ) -> SubmittedTx:
+    ) -> AsyncSubmittedTx:
         """claim rewards.
 
         :param validator: validator
@@ -444,7 +470,7 @@ class LedgerClient(LedgerClientBase):
         tx = Transaction()
         tx.add_message(create_withdraw_delegator_reward(sender.address(), validator))
 
-        return prepare_and_broadcast_basic_transaction(
+        return await prepare_and_broadcast_basic_transaction(
             self,
             tx,
             sender,
@@ -453,26 +479,30 @@ class LedgerClient(LedgerClientBase):
             timeout_height=timeout_height,
         )
 
-    def estimate_gas_for_tx(self, tx: Transaction) -> int:
+    async def estimate_gas_for_tx(self, tx: Transaction) -> int:
         """Estimate gas for transaction.
+
+        Supports both async and (I/O-free) sync gas strategies.
 
         :param tx: transaction
         :return: Estimated gas for transaction
         """
+        if isinstance(self._gas_strategy, AsyncGasStrategy):
+            return await self._gas_strategy.estimate_gas(tx)
         return self._gas_strategy.estimate_gas(tx)
 
     # NOTE(pb): We should come up with a mechanism how this method (or a new one) can return also `Coin`, resp. `Coins`.
-    def estimate_gas_and_fee_for_tx(self, tx: Transaction) -> Tuple[int, str]:
+    async def estimate_gas_and_fee_for_tx(self, tx: Transaction) -> Tuple[int, str]:
         """Estimate gas and fee for transaction.
 
         :param tx: transaction
         :return: estimate gas, fee for transaction
         """
-        gas_estimate = self.estimate_gas_for_tx(tx)
+        gas_estimate = await self.estimate_gas_for_tx(tx)
         fee = self.estimate_fee_from_gas(gas_estimate)
         return gas_estimate, fee
 
-    def wait_for_query_tx(
+    async def wait_for_query_tx(
         self,
         tx_hash: str,
         timeout: Optional[timedelta] = None,
@@ -493,7 +523,7 @@ class LedgerClient(LedgerClientBase):
         start = datetime.now()
         while True:
             try:
-                return self.query_tx(tx_hash)
+                return await self.query_tx(tx_hash)
             except NotFoundError:
                 pass
 
@@ -501,9 +531,9 @@ class LedgerClient(LedgerClientBase):
             if delta >= timeout:
                 raise QueryTimeoutError()
 
-            time.sleep(poll_period.total_seconds())
+            await asyncio.sleep(poll_period.total_seconds())
 
-    def query_tx(self, tx_hash: str) -> TxResponse:
+    async def query_tx(self, tx_hash: str) -> TxResponse:
         """query transaction.
 
         :param tx_hash: transaction hash
@@ -513,7 +543,7 @@ class LedgerClient(LedgerClientBase):
         """
         req = GetTxRequest(hash=tx_hash)
         try:
-            resp = self.txs.GetTx(req)
+            resp = await self.txs.GetTx(req)
         except grpc.RpcError as e:
             if self._is_tx_not_found_error(e):
                 raise NotFoundError() from e
@@ -525,7 +555,7 @@ class LedgerClient(LedgerClientBase):
 
         return self._parse_tx_response(resp.tx_response)
 
-    def simulate_tx(self, tx: Transaction) -> int:
+    async def simulate_tx(self, tx: Transaction) -> int:
         """simulate transaction.
 
         :param tx: transaction
@@ -534,11 +564,11 @@ class LedgerClient(LedgerClientBase):
         self._check_tx_final_for_simulation(tx)
 
         req = SimulateRequest(tx=tx.tx)
-        resp = self.txs.Simulate(req)
+        resp = await self.txs.Simulate(req)
 
         return int(resp.gas_info.gas_used)
 
-    def broadcast_tx(self, tx: Transaction) -> SubmittedTx:
+    async def broadcast_tx(self, tx: Transaction) -> AsyncSubmittedTx:
         """Broadcast transaction.
 
         :param tx: transaction
@@ -550,40 +580,199 @@ class LedgerClient(LedgerClientBase):
         )
 
         # broadcast the transaction
-        resp = self.txs.BroadcastTx(broadcast_req)
+        resp = await self.txs.BroadcastTx(broadcast_req)
         tx_digest = self._check_broadcast_response(resp)
 
-        return SubmittedTx(self, tx_digest)
+        return AsyncSubmittedTx(self, tx_digest)
 
-    def query_latest_block(self) -> Block:
+    async def query_latest_block(self) -> Block:
         """Query the latest block.
 
         :return: latest block
         """
         req = GetLatestBlockRequest()
-        resp = self.tendermint.GetLatestBlock(req)
+        resp = await self.tendermint.GetLatestBlock(req)
         return Block.from_proto(resp.block)
 
-    def query_block(self, height: int) -> Block:
+    async def query_block(self, height: int) -> Block:
         """Query the block.
 
         :param height: block height
         :return: block
         """
         req = GetBlockByHeightRequest(height=height)
-        resp = self.tendermint.GetBlockByHeight(req)
+        resp = await self.tendermint.GetBlockByHeight(req)
         return Block.from_proto(resp.block)
 
-    def query_height(self) -> int:
+    async def query_height(self) -> int:
         """Query the latest block height.
 
         :return: latest block height
         """
-        return self.query_latest_block().height
+        return (await self.query_latest_block()).height
 
-    def query_chain_id(self) -> str:
+    async def query_chain_id(self) -> str:
         """Query the chain id.
 
         :return: chain id
         """
-        return self.query_latest_block().chain_id
+        return (await self.query_latest_block()).chain_id
+
+
+async def simulate_tx(
+    client: AsyncLedgerClient,
+    tx: Transaction,
+    sender: Wallet,
+    account: Optional[Account] = None,
+    memo: Optional[str] = None,
+) -> Tuple[int, str, Account]:
+    """Estimate transaction fees based on either a provided amount, gas limit, or simulation.
+
+    :param client: Async ledger client
+    :param tx: The transaction
+    :param sender: The transaction sender
+    :param account: The account
+    :param memo: Transaction memo, defaults to None
+
+    :return: Estimated gas_limit and fee amount tuple
+    """
+    # query the account information for the sender
+    if account is None:
+        account = await client.query_account(sender.address())
+
+    # we need to build up a representative transaction so that we can accurately simulate it
+    tx.seal(
+        SigningCfg.direct(sender.public_key(), account.sequence),
+        fee=TxFee([], 0),
+        memo=memo,
+    )
+    tx.sign(sender.signer(), client.network_config.chain_id, account.number)
+    tx.complete()
+
+    # simulate the gas and fee for the transaction
+    gas_limit, fee = await client.estimate_gas_and_fee_for_tx(tx)
+
+    return gas_limit, fee, account
+
+
+async def prepare_basic_transaction(
+    client: AsyncLedgerClient,
+    tx: Transaction,
+    sender: Wallet,
+    account: Optional[Account] = None,
+    fee: Optional[TxFee] = None,
+    memo: Optional[str] = None,
+    timeout_height: Optional[int] = None,
+) -> Transaction:
+    """Prepare basic transaction.
+
+    :param client: Async ledger client
+    :param tx: The transaction
+    :param sender: The transaction sender
+    :param account: The account
+    :param fee: The tx fee (see below the behaviour):
+                - If the `fee` *or* `fee.gas_limit` is `None`, then the `simulate_tx(...)` will be executed to
+                  estimate the `fee.gas_limit` value.
+                - If the `fee.amount` is `None` then it will be calculated from the `fee.gas_limit` and `gas_price`
+                  values (the `gas_price` value will be taken from client config).
+    :param memo: Transaction memo, defaults to None
+    :param timeout_height: timeout height, defaults to None
+
+    :return: transaction
+    """
+    if fee is None:
+        fee = TxFee()
+
+    # query the account information for the sender
+    if account is None:
+        account = await client.query_account(sender.address())
+
+    if fee.gas_limit is None:
+        # Simulate transaction to get gas and amount
+        fee.gas_limit, estimated_amount, _ = await simulate_tx(
+            client, tx, sender, account, memo
+        )
+        # Use estimated amount if not provided
+        fee.amount = fee.amount or estimated_amount  # type: ignore
+
+    if fee.amount is None:
+        fee.amount = client.estimate_fee_from_gas(fee.gas_limit)  # type: ignore
+
+    # Build the final transaction
+    tx.seal(
+        SigningCfg.direct(sender.public_key(), account.sequence),
+        fee=fee,
+        memo=memo,
+        timeout_height=timeout_height,
+    )
+
+    tx.sign(sender.signer(), client.network_config.chain_id, account.number)
+    tx.complete()
+
+    return tx
+
+
+async def prepare_and_broadcast_basic_transaction(
+    client: AsyncLedgerClient,
+    tx: Transaction,
+    sender: Wallet,
+    account: Optional[Account] = None,
+    fee: Optional[TxFee] = None,
+    memo: Optional[str] = None,
+    timeout_height: Optional[int] = None,
+) -> AsyncSubmittedTx:
+    """Prepare and broadcast basic transaction.
+
+    :param client: Async ledger client
+    :param tx: The transaction
+    :param sender: The transaction sender
+    :param account: The account
+    :param fee: The tx fee (see below the behaviour):
+                - If the `fee` *or* `fee.gas_limit` is `None`, then the `simulate_tx(...)` will be executed to
+                  estimate the `fee.gas_limit` value.
+                - If the `fee.amount` is `None` then it will be calculated from the `fee.gas_limit` and `gas_price`
+                  values (the `gas_price` value will be taken from client config).
+    :param memo: Transaction memo, defaults to None
+    :param timeout_height: timeout height, defaults to None
+
+    :return: broadcast transaction
+    """
+    tx = await prepare_basic_transaction(
+        client, tx, sender, account, fee, memo, timeout_height
+    )
+    return await client.broadcast_tx(tx)
+
+
+async def get_paginated(
+    initial_request: Any,
+    request_method: Callable,
+    pages_limit: int = 0,
+    per_page_limit: Optional[int] = DEFAULT_PER_PAGE_LIMIT,
+) -> List[Any]:
+    """
+    Get pages for specific request.
+
+    :param initial_request: request supports pagination
+    :param request_method: async function to perform request
+    :param pages_limit: max number of pages to return. default - 0 unlimited
+    :param per_page_limit: Optional int: amount of records per one page. default is None, determined by server
+
+    :return: List of responses
+    """
+    pages: List[Any] = []
+    pagination = PageRequest(limit=per_page_limit)
+
+    while pagination and (len(pages) < pages_limit or pages_limit == 0):
+        request = initial_request.__class__()
+        request.CopyFrom(initial_request)
+        request.pagination.CopyFrom(pagination)
+
+        resp = await request_method(request)
+
+        pages.append(resp)
+
+        pagination = None
+
+        if resp.pagination.next_key:
+            pagination = PageRequest(limit=per_page_limit, key=resp.pagination.next_key)
+    return pages

--- a/cosmpy/aerial/client/base.py
+++ b/cosmpy/aerial/client/base.py
@@ -1,0 +1,389 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2018-2022 Fetch.AI Limited
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""Functionality shared between the sync and async ledger clients.
+
+Everything in this module is I/O free: configuration handling, request/response
+translation and fee arithmetic. The network calls themselves live in the
+concrete clients (``LedgerClient`` and ``AsyncLedgerClient``), which both
+operate on the same generated protobuf stubs.
+"""
+
+import math
+from datetime import timedelta
+from decimal import Decimal
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import certifi
+import grpc
+from dateutil.parser import isoparse
+from packaging.version import Version
+
+from cosmpy.aerial import cast_to_int
+from cosmpy.aerial.client.staking import (
+    StakingPosition,
+    UnbondingPositions,
+    Validator,
+    ValidatorStatus,
+)
+from cosmpy.aerial.client.utils import ensure_timedelta
+from cosmpy.aerial.coins import Coin
+from cosmpy.aerial.config import NetworkConfig
+from cosmpy.aerial.tx import Transaction, TxState
+from cosmpy.aerial.tx_helpers import MessageLog, TxResponse, safe_decode
+from cosmpy.aerial.types import Account, NodeInfo
+from cosmpy.crypto.address import Address
+from cosmpy.protos.cosmos.auth.v1beta1.auth_pb2 import BaseAccount
+from cosmpy.protos.cosmos.auth.v1beta1.query_pb2_grpc import QueryStub as AuthGrpcClient
+from cosmpy.protos.cosmos.bank.v1beta1.query_pb2_grpc import QueryStub as BankGrpcClient
+from cosmpy.protos.cosmos.base.tendermint.v1beta1.query_pb2_grpc import (
+    ServiceStub as TendermintQueryGrpcClient,
+)
+from cosmpy.protos.cosmos.consensus.v1.query_pb2_grpc import (
+    QueryStub as QueryConsensusGrpcClient,
+)
+from cosmpy.protos.cosmos.crypto.ed25519.keys_pb2 import (  # noqa # pylint: disable=unused-import
+    PubKey,
+)
+from cosmpy.protos.cosmos.distribution.v1beta1.query_pb2_grpc import (
+    QueryStub as DistributionGrpcClient,
+)
+from cosmpy.protos.cosmos.params.v1beta1.query_pb2_grpc import (
+    QueryStub as QueryParamsGrpcClient,
+)
+from cosmpy.protos.cosmos.staking.v1beta1.query_pb2_grpc import (
+    QueryStub as StakingGrpcClient,
+)
+from cosmpy.protos.cosmos.tx.v1beta1.service_pb2_grpc import ServiceStub as TxGrpcClient
+from cosmpy.protos.cosmwasm.wasm.v1.query_pb2_grpc import (
+    QueryStub as CosmWasmGrpcClient,
+)
+
+
+DEFAULT_QUERY_TIMEOUT_SECS = 15
+DEFAULT_QUERY_INTERVAL_SECS = 2
+COSMOS_SDK_DEC_COIN_PRECISION = 10**18
+
+
+class LedgerClientBase:
+    """Ledger client base with the functionality shared by the sync and async clients."""
+
+    # query stubs, wired to gRPC or REST backends by the concrete clients
+    wasm: Any
+    auth: Any
+    txs: Any
+    bank: Any
+    staking: Any
+    distribution: Any
+    params: Any
+    consensus: Any
+    tendermint: Any
+
+    def __init__(
+        self,
+        cfg: NetworkConfig,
+        query_interval_secs: int = DEFAULT_QUERY_INTERVAL_SECS,
+        query_timeout_secs: int = DEFAULT_QUERY_TIMEOUT_SECS,
+    ):
+        """Init ledger client base.
+
+        :param cfg: Network configurations
+        :param query_interval_secs: int. optional interval int seconds
+        :param query_timeout_secs: int. optional interval int seconds
+        """
+        self._query_interval_secs = query_interval_secs
+        self._query_timeout_secs = query_timeout_secs
+        cfg.validate()
+        self._network_config = cfg
+
+    @property
+    def network_config(self) -> NetworkConfig:
+        """Get the network config.
+
+        :return: network config
+        """
+        return self._network_config
+
+    def _init_grpc_stubs(self, grpc_client):
+        """Create the generated protobuf stubs on the given channel.
+
+        The generated stub classes work with both a synchronous ``grpc.Channel``
+        and an asynchronous ``grpc.aio.Channel``: with the latter, the stub
+        methods return awaitables.
+
+        :param grpc_client: gRPC channel (sync or aio)
+        """
+        self.wasm = CosmWasmGrpcClient(grpc_client)
+        self.auth = AuthGrpcClient(grpc_client)
+        self.txs = TxGrpcClient(grpc_client)
+        self.bank = BankGrpcClient(grpc_client)
+        self.staking = StakingGrpcClient(grpc_client)
+        self.distribution = DistributionGrpcClient(grpc_client)
+        self.params = QueryParamsGrpcClient(grpc_client)
+        self.consensus = QueryConsensusGrpcClient(grpc_client)
+        self.tendermint = TendermintQueryGrpcClient(grpc_client)
+
+    @staticmethod
+    def _create_ssl_credentials() -> grpc.ChannelCredentials:
+        """Create SSL channel credentials using the certifi CA bundle.
+
+        :return: gRPC channel credentials
+        """
+        with open(certifi.where(), "rb") as f:
+            trusted_certs = f.read()
+        return grpc.ssl_channel_credentials(root_certificates=trusted_certs)
+
+    # NOTE(pb): We should come up with a mechanism how this method (or a new one) can return also `Coin`, resp. `Coins`.
+    def estimate_fee_from_gas(self, gas_limit: int) -> str:
+        """Estimate fee from gas.
+
+        :param gas_limit: gas limit
+        :return: Estimated fee for transaction
+        """
+        fee = math.ceil(gas_limit * self.network_config.fee_minimum_gas_price)
+        return f"{fee}{self.network_config.fee_denomination}"
+
+    def _resolve_tx_poll_timings(
+        self,
+        timeout: Optional[Union[int, float, timedelta]],
+        poll_period: Optional[Union[int, float, timedelta]],
+    ) -> Tuple[timedelta, timedelta]:
+        """Resolve tx polling timeout and poll period, falling back to client defaults.
+
+        :param timeout: optional timeout
+        :param poll_period: optional poll period
+        :return: timeout and poll period timedeltas
+        """
+        resolved_timeout = (
+            ensure_timedelta(timeout)
+            if timeout
+            else timedelta(seconds=self._query_timeout_secs)
+        )
+        resolved_poll_period = (
+            ensure_timedelta(poll_period)
+            if poll_period
+            else timedelta(seconds=self._query_interval_secs)
+        )
+        return resolved_timeout, resolved_poll_period
+
+    @staticmethod
+    def _parse_account(response: Any, address: Address) -> Account:
+        """Parse a QueryAccountResponse into an Account.
+
+        :param response: query account response
+        :param address: queried address
+        :raises RuntimeError: Unexpected account type returned from query
+        :return: account details
+        """
+        account = BaseAccount()
+        if not response.account.Is(BaseAccount.DESCRIPTOR):
+            raise RuntimeError("Unexpected account type returned from query")
+        response.account.Unpack(account)
+
+        return Account(
+            address=address,
+            number=account.account_number,
+            sequence=account.sequence,
+        )
+
+    @staticmethod
+    def _parse_node_info(response: Any) -> NodeInfo:
+        """Parse a GetNodeInfoResponse into a NodeInfo.
+
+        :param response: get node info response
+        :return: NodeInfo
+        """
+        cosmos_sdk_version = Version(
+            response.application_version.cosmos_sdk_version.lstrip("v")
+        )
+        app_name = response.application_version.name
+        app_version = Version(response.application_version.version.lstrip("v"))
+
+        return NodeInfo(
+            cosmos_sdk_version=cosmos_sdk_version,
+            app_name=app_name,
+            app_version=app_version,
+        )
+
+    @staticmethod
+    def _parse_bank_balance(resp: Any, denom: str) -> int:
+        """Parse a QueryBalanceResponse into an amount.
+
+        :param resp: query balance response
+        :param denom: queried denomination
+        :return: balance amount
+        """
+        assert resp.balance.denom == denom  # sanity check
+        return int(resp.balance.amount)
+
+    @staticmethod
+    def _parse_bank_all_balances(resp: Any) -> List[Coin]:
+        """Parse a QueryAllBalancesResponse into a list of coins.
+
+        :param resp: query all balances response
+        :return: list of coins
+        """
+        return [Coin(amount=coin.amount, denom=coin.denom) for coin in resp.balances]
+
+    @staticmethod
+    def _parse_validators(resp: Any) -> List[Validator]:
+        """Parse a QueryValidatorsResponse into a list of validators.
+
+        :param resp: query validators response
+        :return: list of validators
+        """
+        validators: List[Validator] = []
+        for validator in resp.validators:
+            validators.append(
+                Validator(
+                    address=Address(validator.operator_address),
+                    tokens=cast_to_int(validator.tokens, False),
+                    moniker=str(validator.description.moniker),
+                    status=ValidatorStatus.from_proto(validator.status),
+                )
+            )
+        return validators
+
+    def _parse_staking_position(self, item: Any, rewards_resp: Any) -> StakingPosition:
+        """Build a StakingPosition from a delegation item and its rewards response.
+
+        :param item: delegation response item
+        :param rewards_resp: delegation rewards response
+        :return: staking position
+        """
+        stake_reward_dec = Decimal(0)
+        stake_reward = 0
+        for reward in rewards_resp.rewards:
+            if reward.denom == self.network_config.staking_denomination:
+                stake_reward_dec = Decimal(reward.amount)
+                stake_reward = cast_to_int(reward.amount, False)
+                break
+
+        return StakingPosition(
+            validator=Address(item.delegation.validator_address),
+            amount=cast_to_int(item.balance.amount, False),
+            reward=stake_reward,
+            reward_dec=stake_reward_dec,
+        )
+
+    @staticmethod
+    def _build_unbonding_positions(
+        unbonding_pages: List[Any],
+    ) -> List[UnbondingPositions]:
+        """Build the list of unbonding positions from paginated unbonding responses.
+
+        :param unbonding_pages: pages of DelegatorUnbondingDelegations responses
+        :return: list of unbonding positions
+        """
+        unbonding_summary: Dict[str, int] = {}
+        for resp in unbonding_pages:
+            for item in resp.unbonding_responses:
+                validator = str(item.validator_address)
+                total_unbonding = unbonding_summary.get(validator, 0)
+
+                for entry in item.entries:
+                    total_unbonding += cast_to_int(entry.balance, False)
+
+                unbonding_summary[validator] = total_unbonding
+
+        # build the final list of unbonding positions
+        unbonding_positions: List[UnbondingPositions] = []
+        for validator, total_unbonding in unbonding_summary.items():
+            unbonding_positions.append(
+                UnbondingPositions(
+                    validator=Address(validator),
+                    amount=total_unbonding,
+                )
+            )
+        return unbonding_positions
+
+    @staticmethod
+    def _is_tx_not_found_error(error: Exception) -> bool:
+        """Check whether a failed GetTx call indicates a missing transaction.
+
+        :param error: exception raised by the GetTx call
+        :return: True if the error indicates the tx is not (yet) found
+        """
+        if isinstance(error, grpc.RpcError):
+            return "not found" in error.details()
+        details = str(error)
+        return "tx" in details and "not found" in details
+
+    @staticmethod
+    def _check_tx_final_for_simulation(tx: Transaction):
+        """Ensure the transaction can be simulated.
+
+        :param tx: transaction
+        :raises RuntimeError: Unable to simulate non final transaction
+        """
+        if tx.state != TxState.Final:
+            raise RuntimeError("Unable to simulate non final transaction")
+
+    @staticmethod
+    def _parse_tx_response(tx_response: Any) -> TxResponse:
+        # parse the transaction logs
+        logs = []
+        for log_data in tx_response.logs:
+            events = {}
+            for event in log_data.events:
+                events[event.type] = {a.key: a.value for a in event.attributes}
+            logs.append(
+                MessageLog(
+                    index=int(log_data.msg_index), log=log_data.msg_index, events=events
+                )
+            )
+
+        # parse the transaction events
+        events = {}
+        for event in tx_response.events:
+            event_data = events.get(event.type, {})
+            for attribute in event.attributes:
+                event_data[safe_decode(attribute.key)] = safe_decode(attribute.value)
+            events[event.type] = event_data
+
+        timestamp = None
+        if tx_response.timestamp:
+            timestamp = isoparse(tx_response.timestamp)
+
+        return TxResponse(
+            hash=str(tx_response.txhash),
+            height=int(tx_response.height),
+            code=int(tx_response.code),
+            gas_wanted=int(tx_response.gas_wanted),
+            gas_used=int(tx_response.gas_used),
+            raw_log=str(tx_response.raw_log),
+            logs=logs,
+            events=events,
+            timestamp=timestamp,
+        )
+
+    @classmethod
+    def _check_broadcast_response(cls, resp: Any) -> str:
+        """Check a BroadcastTxResponse and return the tx digest.
+
+        :param resp: broadcast tx response
+        :return: transaction digest
+        """
+        tx_digest = resp.tx_response.txhash
+
+        # check that the response is successful
+        initial_tx_response = cls._parse_tx_response(resp.tx_response)
+        initial_tx_response.ensure_successful()
+
+        return tx_digest

--- a/cosmpy/aerial/gas.py
+++ b/cosmpy/aerial/gas.py
@@ -110,6 +110,81 @@ class SimulationGasStrategy(GasStrategy):
         return self._max_gas or -1
 
 
+class AsyncGasStrategy(ABC):
+    """Transaction gas strategy for the async ledger client."""
+
+    @abstractmethod
+    async def estimate_gas(self, tx: Transaction) -> int:
+        """Estimate the transaction gas.
+
+        :param tx: Transaction
+        :return: None
+        """
+
+    @abstractmethod
+    async def block_gas_limit(self) -> int:
+        """Get the block gas limit.
+
+        :return: None
+        """
+
+    async def _clip_gas(self, value: int) -> int:
+        block_limit = await self.block_gas_limit()
+        if block_limit < 0:
+            return value
+
+        return min(value, block_limit)
+
+
+class AsyncSimulationGasStrategy(AsyncGasStrategy):
+    """Simulation transaction gas strategy for the async ledger client.
+
+    :param AsyncGasStrategy: async gas strategy
+    """
+
+    DEFAULT_MULTIPLIER = 1.65
+
+    def __init__(self, client: "AsyncLedgerClient", multiplier: Optional[float] = None):  # type: ignore # noqa: F821
+        """Init the Simulation transaction gas strategy.
+
+        :param client: Async ledger client
+        :param multiplier: multiplier, defaults to None
+        """
+        self._client = client
+        self._max_gas: Optional[int] = None
+        self._multiplier = multiplier or self.DEFAULT_MULTIPLIER
+
+    async def estimate_gas(self, tx: Transaction) -> int:
+        """Get estimated transaction gas.
+
+        :param tx: transaction
+        :return: Estimated transaction gas
+        """
+        gas_estimate = await self._client.simulate_tx(tx)
+        return await self._clip_gas(int(gas_estimate * self._multiplier))
+
+    async def block_gas_limit(self) -> int:
+        """Get the block gas limit.
+
+        :raises Exception: Failed to query max_gas
+        :return: block gas limit
+        """
+        if self._max_gas is None:
+            try:
+                params = await self._client.query_consensus_params()
+                self._max_gas = int(params.params.block.max_gas)
+            except Exception as e:  # pylint: disable=broad-except
+                try:
+                    block_params = await self._client.query_params(
+                        "baseapp", "BlockParams"
+                    )
+                    self._max_gas = int(block_params["max_gas"])
+                except Exception as f:  # pylint: disable=broad-except
+                    raise f from e
+
+        return self._max_gas or -1
+
+
 class OfflineMessageTableStrategy(GasStrategy):
     """Offline message table strategy.
 

--- a/cosmpy/aerial/tx_helpers.py
+++ b/cosmpy/aerial/tx_helpers.py
@@ -181,6 +181,30 @@ class SubmittedTx:
         return self
 
 
+class AsyncSubmittedTx(SubmittedTx):
+    """Submitted transaction bound to an AsyncLedgerClient."""
+
+    async def wait_to_complete(  # type: ignore[override] # pylint: disable=invalid-overridden-method
+        self,
+        timeout: Optional[Union[int, float, timedelta]] = None,
+        poll_period: Optional[Union[int, float, timedelta]] = None,
+    ) -> "AsyncSubmittedTx":
+        """Wait to complete the transaction.
+
+        :param timeout: timeout, defaults to None
+        :param poll_period: poll_period, defaults to None
+
+        :return: Submitted Transaction
+        """
+        self._response = await self._client.wait_for_query_tx(
+            self.tx_hash, timeout=timeout, poll_period=poll_period
+        )
+        assert self._response is not None
+        self._response.ensure_successful()
+
+        return self
+
+
 def safe_decode(v):
     """
     Decode a value from bytes to UTF-8 string if necessary.

--- a/docs/api/aerial/client/__init__.md
+++ b/docs/api/aerial/client/__init__.md
@@ -9,7 +9,7 @@ Client functionality.
 ## LedgerClient Objects
 
 ```python
-class LedgerClient()
+class LedgerClient(LedgerClientBase)
 ```
 
 Ledger client.
@@ -31,21 +31,6 @@ Init ledger client.
 - `cfg`: Network configurations
 - `query_interval_secs`: int. optional interval int seconds
 - `query_timeout_secs`: int. optional interval int seconds
-
-<a id="cosmpy.aerial.client.__init__.LedgerClient.network_config"></a>
-
-#### network`_`config
-
-```python
-@property
-def network_config() -> NetworkConfig
-```
-
-Get the network config.
-
-**Returns**:
-
-network config
 
 <a id="cosmpy.aerial.client.__init__.LedgerClient.gas_strategy"></a>
 
@@ -94,10 +79,6 @@ Query account.
 **Arguments**:
 
 - `address`: address
-
-**Raises**:
-
-- `RuntimeError`: Unexpected account type returned from query
 
 **Returns**:
 
@@ -384,24 +365,6 @@ Estimate gas for transaction.
 
 Estimated gas for transaction
 
-<a id="cosmpy.aerial.client.__init__.LedgerClient.estimate_fee_from_gas"></a>
-
-#### estimate`_`fee`_`from`_`gas
-
-```python
-def estimate_fee_from_gas(gas_limit: int) -> str
-```
-
-Estimate fee from gas.
-
-**Arguments**:
-
-- `gas_limit`: gas limit
-
-**Returns**:
-
-Estimated fee for transaction
-
 <a id="cosmpy.aerial.client.__init__.LedgerClient.estimate_gas_and_fee_for_tx"></a>
 
 #### estimate`_`gas`_`and`_`fee`_`for`_`tx
@@ -482,10 +445,6 @@ simulate transaction.
 **Arguments**:
 
 - `tx`: transaction
-
-**Raises**:
-
-- `RuntimeError`: Unable to simulate non final transaction
 
 **Returns**:
 

--- a/docs/api/aerial/client/aio.md
+++ b/docs/api/aerial/client/aio.md
@@ -1,0 +1,720 @@
+<a id="cosmpy.aerial.client.aio"></a>
+
+# cosmpy.aerial.client.aio
+
+Asyncio-native client functionality (gRPC endpoints only).
+
+``AsyncLedgerClient`` mirrors ``LedgerClient`` method for method, but performs
+all network I/O on grpc's native asyncio channel (``grpc.aio``) — no worker
+threads involved. It reuses the same generated protobuf stubs as the sync
+client; the stubs return awaitables when constructed over an aio channel.
+
+Note: instantiate the client from within a running event loop (i.e. inside the
+coroutine passed to ``asyncio.run``) — the underlying grpc.aio channel binds to
+the running loop when it is created.
+
+Usage:
+
+.. code-block:: python
+
+async with AsyncLedgerClient(NetworkConfig.fetchai_mainnet()) as client:
+balance = await client.query_bank_balance(address)
+
+<a id="cosmpy.aerial.client.aio.AsyncLedgerClient"></a>
+
+## AsyncLedgerClient Objects
+
+```python
+class AsyncLedgerClient(LedgerClientBase)
+```
+
+Asyncio-native ledger client (gRPC endpoints only).
+
+<a id="cosmpy.aerial.client.aio.AsyncLedgerClient.__init__"></a>
+
+#### `__`init`__`
+
+```python
+def __init__(cfg: NetworkConfig,
+             query_interval_secs: int = DEFAULT_QUERY_INTERVAL_SECS,
+             query_timeout_secs: int = DEFAULT_QUERY_TIMEOUT_SECS)
+```
+
+Init async ledger client.
+
+**Arguments**:
+
+- `cfg`: Network configurations
+- `query_interval_secs`: int. optional interval int seconds
+- `query_timeout_secs`: int. optional interval int seconds
+
+**Raises**:
+
+- `RuntimeError`: Network config url is not a gRPC endpoint
+
+<a id="cosmpy.aerial.client.aio.AsyncLedgerClient.close"></a>
+
+#### close
+
+```python
+async def close()
+```
+
+Close the underlying gRPC channel.
+
+<a id="cosmpy.aerial.client.aio.AsyncLedgerClient.__aenter__"></a>
+
+#### `__`aenter`__`
+
+```python
+async def __aenter__() -> "AsyncLedgerClient"
+```
+
+Enter the async context.
+
+**Returns**:
+
+this client
+
+<a id="cosmpy.aerial.client.aio.AsyncLedgerClient.__aexit__"></a>
+
+#### `__`aexit`__`
+
+```python
+async def __aexit__(exc_type, exc_value, traceback)
+```
+
+Exit the async context, closing the gRPC channel.
+
+**Arguments**:
+
+- `exc_type`: exception type
+- `exc_value`: exception value
+- `traceback`: exception traceback
+
+<a id="cosmpy.aerial.client.aio.AsyncLedgerClient.gas_strategy"></a>
+
+#### gas`_`strategy
+
+```python
+@property
+def gas_strategy() -> Union[GasStrategy, AsyncGasStrategy]
+```
+
+Get gas strategy.
+
+**Returns**:
+
+gas strategy
+
+<a id="cosmpy.aerial.client.aio.AsyncLedgerClient.gas_strategy"></a>
+
+#### gas`_`strategy
+
+```python
+@gas_strategy.setter
+def gas_strategy(strategy: Union[GasStrategy, AsyncGasStrategy])
+```
+
+Set gas strategy.
+
+**Arguments**:
+
+- `strategy`: strategy
+
+**Raises**:
+
+- `RuntimeError`: Invalid strategy must implement GasStrategy or AsyncGasStrategy interface
+
+<a id="cosmpy.aerial.client.aio.AsyncLedgerClient.query_account"></a>
+
+#### query`_`account
+
+```python
+async def query_account(address: Address) -> Account
+```
+
+Query account.
+
+**Arguments**:
+
+- `address`: address
+
+**Returns**:
+
+account details
+
+<a id="cosmpy.aerial.client.aio.AsyncLedgerClient.query_params"></a>
+
+#### query`_`params
+
+```python
+async def query_params(subspace: str, key: str) -> Any
+```
+
+Query Prams.
+
+**Arguments**:
+
+- `subspace`: subspace
+- `key`: key
+
+**Returns**:
+
+Query params
+
+<a id="cosmpy.aerial.client.aio.AsyncLedgerClient.query_node_info"></a>
+
+#### query`_`node`_`info
+
+```python
+async def query_node_info() -> NodeInfo
+```
+
+Query basic Tendermint / node information (moniker, chain-id, version, etc.).
+
+**Returns**:
+
+NodeInfo.
+
+<a id="cosmpy.aerial.client.aio.AsyncLedgerClient.query_consensus_params"></a>
+
+#### query`_`consensus`_`params
+
+```python
+async def query_consensus_params() -> Any
+```
+
+Query consensus params.
+
+**Returns**:
+
+Query consensus params
+
+<a id="cosmpy.aerial.client.aio.AsyncLedgerClient.query_bank_balance"></a>
+
+#### query`_`bank`_`balance
+
+```python
+async def query_bank_balance(address: Address,
+                             denom: Optional[str] = None) -> int
+```
+
+Query bank balance.
+
+**Arguments**:
+
+- `address`: address
+- `denom`: denom, defaults to None
+
+**Returns**:
+
+bank balance
+
+<a id="cosmpy.aerial.client.aio.AsyncLedgerClient.query_bank_all_balances"></a>
+
+#### query`_`bank`_`all`_`balances
+
+```python
+async def query_bank_all_balances(address: Address) -> List[Coin]
+```
+
+Query bank all balances.
+
+**Arguments**:
+
+- `address`: address
+
+**Returns**:
+
+bank all balances
+
+<a id="cosmpy.aerial.client.aio.AsyncLedgerClient.send_tokens"></a>
+
+#### send`_`tokens
+
+```python
+async def send_tokens(
+        destination: Address,
+        amount: int,
+        denom: str,
+        sender: Wallet,
+        memo: Optional[str] = None,
+        fee: Optional[TxFee] = None,
+        timeout_height: Optional[int] = None) -> AsyncSubmittedTx
+```
+
+Send tokens.
+
+**Arguments**:
+
+- `destination`: destination address
+- `amount`: amount
+- `denom`: denom
+- `sender`: sender
+- `memo`: memo, defaults to None
+- `fee`: transaction fee, defaults to None
+- `timeout_height`: timeout height, defaults to None
+
+**Returns**:
+
+prepare and broadcast the transaction and transaction details
+
+<a id="cosmpy.aerial.client.aio.AsyncLedgerClient.query_validators"></a>
+
+#### query`_`validators
+
+```python
+async def query_validators(
+        status: Optional[ValidatorStatus] = None) -> List[Validator]
+```
+
+Query validators.
+
+**Arguments**:
+
+- `status`: validator status, defaults to None
+
+**Returns**:
+
+List of validators
+
+<a id="cosmpy.aerial.client.aio.AsyncLedgerClient.query_staking_summary"></a>
+
+#### query`_`staking`_`summary
+
+```python
+async def query_staking_summary(address: Address) -> StakingSummary
+```
+
+Query staking summary.
+
+**Arguments**:
+
+- `address`: address
+
+**Returns**:
+
+staking summary
+
+<a id="cosmpy.aerial.client.aio.AsyncLedgerClient.delegate_tokens"></a>
+
+#### delegate`_`tokens
+
+```python
+async def delegate_tokens(
+        validator: Address,
+        amount: int,
+        sender: Wallet,
+        memo: Optional[str] = None,
+        fee: Optional[TxFee] = None,
+        timeout_height: Optional[int] = None) -> AsyncSubmittedTx
+```
+
+Delegate tokens.
+
+**Arguments**:
+
+- `validator`: validator address
+- `amount`: amount
+- `sender`: sender
+- `memo`: memo, defaults to None
+- `fee`: transaction fee, defaults to None
+- `timeout_height`: timeout height, defaults to None
+
+**Returns**:
+
+prepare and broadcast the transaction and transaction details
+
+<a id="cosmpy.aerial.client.aio.AsyncLedgerClient.redelegate_tokens"></a>
+
+#### redelegate`_`tokens
+
+```python
+async def redelegate_tokens(
+        current_validator: Address,
+        next_validator: Address,
+        amount: int,
+        sender: Wallet,
+        memo: Optional[str] = None,
+        fee: Optional[TxFee] = None,
+        timeout_height: Optional[int] = None) -> AsyncSubmittedTx
+```
+
+Redelegate tokens.
+
+**Arguments**:
+
+- `current_validator`: current validator address
+- `next_validator`: next validator address
+- `amount`: amount
+- `sender`: sender
+- `memo`: memo, defaults to None
+- `fee`: transaction fee, defaults to None
+- `timeout_height`: timeout height, defaults to None
+
+**Returns**:
+
+prepare and broadcast the transaction and transaction details
+
+<a id="cosmpy.aerial.client.aio.AsyncLedgerClient.undelegate_tokens"></a>
+
+#### undelegate`_`tokens
+
+```python
+async def undelegate_tokens(
+        validator: Address,
+        amount: int,
+        sender: Wallet,
+        memo: Optional[str] = None,
+        fee: Optional[TxFee] = None,
+        timeout_height: Optional[int] = None) -> AsyncSubmittedTx
+```
+
+Undelegate tokens.
+
+**Arguments**:
+
+- `validator`: validator
+- `amount`: amount
+- `sender`: sender
+- `memo`: memo, defaults to None
+- `fee`: transaction fee, defaults to None
+- `timeout_height`: timeout height, defaults to None
+
+**Returns**:
+
+prepare and broadcast the transaction and transaction details
+
+<a id="cosmpy.aerial.client.aio.AsyncLedgerClient.claim_rewards"></a>
+
+#### claim`_`rewards
+
+```python
+async def claim_rewards(
+        validator: Address,
+        sender: Wallet,
+        memo: Optional[str] = None,
+        fee: Optional[TxFee] = None,
+        timeout_height: Optional[int] = None) -> AsyncSubmittedTx
+```
+
+claim rewards.
+
+**Arguments**:
+
+- `validator`: validator
+- `sender`: sender
+- `memo`: memo, defaults to None
+- `fee`: transaction fee, defaults to None
+- `timeout_height`: timeout height, defaults to None
+
+**Returns**:
+
+prepare and broadcast the transaction and transaction details
+
+<a id="cosmpy.aerial.client.aio.AsyncLedgerClient.estimate_gas_for_tx"></a>
+
+#### estimate`_`gas`_`for`_`tx
+
+```python
+async def estimate_gas_for_tx(tx: Transaction) -> int
+```
+
+Estimate gas for transaction.
+
+Supports both async and (I/O-free) sync gas strategies.
+
+**Arguments**:
+
+- `tx`: transaction
+
+**Returns**:
+
+Estimated gas for transaction
+
+<a id="cosmpy.aerial.client.aio.AsyncLedgerClient.estimate_gas_and_fee_for_tx"></a>
+
+#### estimate`_`gas`_`and`_`fee`_`for`_`tx
+
+```python
+async def estimate_gas_and_fee_for_tx(tx: Transaction) -> Tuple[int, str]
+```
+
+Estimate gas and fee for transaction.
+
+**Arguments**:
+
+- `tx`: transaction
+
+**Returns**:
+
+estimate gas, fee for transaction
+
+<a id="cosmpy.aerial.client.aio.AsyncLedgerClient.wait_for_query_tx"></a>
+
+#### wait`_`for`_`query`_`tx
+
+```python
+async def wait_for_query_tx(
+        tx_hash: str,
+        timeout: Optional[timedelta] = None,
+        poll_period: Optional[timedelta] = None) -> TxResponse
+```
+
+Wait for query transaction.
+
+**Arguments**:
+
+- `tx_hash`: transaction hash
+- `timeout`: timeout, defaults to None
+- `poll_period`: poll_period, defaults to None
+
+**Raises**:
+
+- `QueryTimeoutError`: timeout
+
+**Returns**:
+
+transaction response
+
+<a id="cosmpy.aerial.client.aio.AsyncLedgerClient.query_tx"></a>
+
+#### query`_`tx
+
+```python
+async def query_tx(tx_hash: str) -> TxResponse
+```
+
+query transaction.
+
+**Arguments**:
+
+- `tx_hash`: transaction hash
+
+**Raises**:
+
+- `NotFoundError`: Tx details not found
+- `grpc.RpcError`: RPC connection issue
+
+**Returns**:
+
+query response
+
+<a id="cosmpy.aerial.client.aio.AsyncLedgerClient.simulate_tx"></a>
+
+#### simulate`_`tx
+
+```python
+async def simulate_tx(tx: Transaction) -> int
+```
+
+simulate transaction.
+
+**Arguments**:
+
+- `tx`: transaction
+
+**Returns**:
+
+gas used in transaction
+
+<a id="cosmpy.aerial.client.aio.AsyncLedgerClient.broadcast_tx"></a>
+
+#### broadcast`_`tx
+
+```python
+async def broadcast_tx(tx: Transaction) -> AsyncSubmittedTx
+```
+
+Broadcast transaction.
+
+**Arguments**:
+
+- `tx`: transaction
+
+**Returns**:
+
+Submitted transaction
+
+<a id="cosmpy.aerial.client.aio.AsyncLedgerClient.query_latest_block"></a>
+
+#### query`_`latest`_`block
+
+```python
+async def query_latest_block() -> Block
+```
+
+Query the latest block.
+
+**Returns**:
+
+latest block
+
+<a id="cosmpy.aerial.client.aio.AsyncLedgerClient.query_block"></a>
+
+#### query`_`block
+
+```python
+async def query_block(height: int) -> Block
+```
+
+Query the block.
+
+**Arguments**:
+
+- `height`: block height
+
+**Returns**:
+
+block
+
+<a id="cosmpy.aerial.client.aio.AsyncLedgerClient.query_height"></a>
+
+#### query`_`height
+
+```python
+async def query_height() -> int
+```
+
+Query the latest block height.
+
+**Returns**:
+
+latest block height
+
+<a id="cosmpy.aerial.client.aio.AsyncLedgerClient.query_chain_id"></a>
+
+#### query`_`chain`_`id
+
+```python
+async def query_chain_id() -> str
+```
+
+Query the chain id.
+
+**Returns**:
+
+chain id
+
+<a id="cosmpy.aerial.client.aio.simulate_tx"></a>
+
+#### simulate`_`tx
+
+```python
+async def simulate_tx(client: AsyncLedgerClient,
+                      tx: Transaction,
+                      sender: Wallet,
+                      account: Optional[Account] = None,
+                      memo: Optional[str] = None) -> Tuple[int, str, Account]
+```
+
+Estimate transaction fees based on either a provided amount, gas limit, or simulation.
+
+**Arguments**:
+
+- `client`: Async ledger client
+- `tx`: The transaction
+- `sender`: The transaction sender
+- `account`: The account
+- `memo`: Transaction memo, defaults to None
+
+**Returns**:
+
+Estimated gas_limit and fee amount tuple
+
+<a id="cosmpy.aerial.client.aio.prepare_basic_transaction"></a>
+
+#### prepare`_`basic`_`transaction
+
+```python
+async def prepare_basic_transaction(
+        client: AsyncLedgerClient,
+        tx: Transaction,
+        sender: Wallet,
+        account: Optional[Account] = None,
+        fee: Optional[TxFee] = None,
+        memo: Optional[str] = None,
+        timeout_height: Optional[int] = None) -> Transaction
+```
+
+Prepare basic transaction.
+
+**Arguments**:
+
+- `client`: Async ledger client
+- `tx`: The transaction
+- `sender`: The transaction sender
+- `account`: The account
+- `fee`: The tx fee (see below the behaviour):
+- If the `fee` *or* `fee.gas_limit` is `None`, then the `simulate_tx(...)` will be executed to
+  estimate the `fee.gas_limit` value.
+- If the `fee.amount` is `None` then it will be calculated from the `fee.gas_limit` and `gas_price`
+  values (the `gas_price` value will be taken from client config).
+- `memo`: Transaction memo, defaults to None
+- `timeout_height`: timeout height, defaults to None
+
+**Returns**:
+
+transaction
+
+<a id="cosmpy.aerial.client.aio.prepare_and_broadcast_basic_transaction"></a>
+
+#### prepare`_`and`_`broadcast`_`basic`_`transaction
+
+```python
+async def prepare_and_broadcast_basic_transaction(
+        client: AsyncLedgerClient,
+        tx: Transaction,
+        sender: Wallet,
+        account: Optional[Account] = None,
+        fee: Optional[TxFee] = None,
+        memo: Optional[str] = None,
+        timeout_height: Optional[int] = None) -> AsyncSubmittedTx
+```
+
+Prepare and broadcast basic transaction.
+
+**Arguments**:
+
+- `client`: Async ledger client
+- `tx`: The transaction
+- `sender`: The transaction sender
+- `account`: The account
+- `fee`: The tx fee (see below the behaviour):
+- If the `fee` *or* `fee.gas_limit` is `None`, then the `simulate_tx(...)` will be executed to
+  estimate the `fee.gas_limit` value.
+- If the `fee.amount` is `None` then it will be calculated from the `fee.gas_limit` and `gas_price`
+  values (the `gas_price` value will be taken from client config).
+- `memo`: Transaction memo, defaults to None
+- `timeout_height`: timeout height, defaults to None
+
+**Returns**:
+
+broadcast transaction
+
+<a id="cosmpy.aerial.client.aio.get_paginated"></a>
+
+#### get`_`paginated
+
+```python
+async def get_paginated(
+        initial_request: Any,
+        request_method: Callable,
+        pages_limit: int = 0,
+        per_page_limit: Optional[int] = DEFAULT_PER_PAGE_LIMIT) -> List[Any]
+```
+
+Get pages for specific request.
+
+**Arguments**:
+
+- `initial_request`: request supports pagination
+- `request_method`: async function to perform request
+- `pages_limit`: max number of pages to return. default - 0 unlimited
+- `per_page_limit`: Optional int: amount of records per one page. default is None, determined by server
+
+**Returns**:
+
+List of responses
+

--- a/docs/api/aerial/client/base.md
+++ b/docs/api/aerial/client/base.md
@@ -1,0 +1,72 @@
+<a id="cosmpy.aerial.client.base"></a>
+
+# cosmpy.aerial.client.base
+
+Functionality shared between the sync and async ledger clients.
+
+Everything in this module is I/O free: configuration handling, request/response
+translation and fee arithmetic. The network calls themselves live in the
+concrete clients (``LedgerClient`` and ``AsyncLedgerClient``), which both
+operate on the same generated protobuf stubs.
+
+<a id="cosmpy.aerial.client.base.LedgerClientBase"></a>
+
+## LedgerClientBase Objects
+
+```python
+class LedgerClientBase()
+```
+
+Ledger client base with the functionality shared by the sync and async clients.
+
+<a id="cosmpy.aerial.client.base.LedgerClientBase.__init__"></a>
+
+#### `__`init`__`
+
+```python
+def __init__(cfg: NetworkConfig,
+             query_interval_secs: int = DEFAULT_QUERY_INTERVAL_SECS,
+             query_timeout_secs: int = DEFAULT_QUERY_TIMEOUT_SECS)
+```
+
+Init ledger client base.
+
+**Arguments**:
+
+- `cfg`: Network configurations
+- `query_interval_secs`: int. optional interval int seconds
+- `query_timeout_secs`: int. optional interval int seconds
+
+<a id="cosmpy.aerial.client.base.LedgerClientBase.network_config"></a>
+
+#### network`_`config
+
+```python
+@property
+def network_config() -> NetworkConfig
+```
+
+Get the network config.
+
+**Returns**:
+
+network config
+
+<a id="cosmpy.aerial.client.base.LedgerClientBase.estimate_fee_from_gas"></a>
+
+#### estimate`_`fee`_`from`_`gas
+
+```python
+def estimate_fee_from_gas(gas_limit: int) -> str
+```
+
+Estimate fee from gas.
+
+**Arguments**:
+
+- `gas_limit`: gas limit
+
+**Returns**:
+
+Estimated fee for transaction
+

--- a/docs/api/aerial/client/staking.md
+++ b/docs/api/aerial/client/staking.md
@@ -70,6 +70,18 @@ class Validator()
 
 Validator.
 
+<a id="cosmpy.aerial.client.staking.Validator.address"></a>
+
+#### address
+
+the operators address
+
+<a id="cosmpy.aerial.client.staking.Validator.tokens"></a>
+
+#### tokens
+
+The total amount of tokens for the validator
+
 <a id="cosmpy.aerial.client.staking.StakingSummary"></a>
 
 ## StakingSummary Objects

--- a/docs/api/aerial/client/staking.md
+++ b/docs/api/aerial/client/staking.md
@@ -70,18 +70,6 @@ class Validator()
 
 Validator.
 
-<a id="cosmpy.aerial.client.staking.Validator.address"></a>
-
-#### address
-
-the operators address
-
-<a id="cosmpy.aerial.client.staking.Validator.tokens"></a>
-
-#### tokens
-
-The total amount of tokens for the validator
-
 <a id="cosmpy.aerial.client.staking.StakingSummary"></a>
 
 ## StakingSummary Objects

--- a/docs/api/aerial/faucet.md
+++ b/docs/api/aerial/faucet.md
@@ -14,6 +14,30 @@ class FaucetApi()
 
 Faucet API.
 
+<a id="cosmpy.aerial.faucet.FaucetApi.FAUCET_STATUS_PENDING"></a>
+
+#### FAUCET`_`STATUS`_`PENDING
+
+noqa: F841
+
+<a id="cosmpy.aerial.faucet.FaucetApi.FAUCET_STATUS_PROCESSING"></a>
+
+#### FAUCET`_`STATUS`_`PROCESSING
+
+noqa: F841
+
+<a id="cosmpy.aerial.faucet.FaucetApi.FAUCET_STATUS_COMPLETED"></a>
+
+#### FAUCET`_`STATUS`_`COMPLETED
+
+noqa: F841
+
+<a id="cosmpy.aerial.faucet.FaucetApi.FAUCET_STATUS_FAILED"></a>
+
+#### FAUCET`_`STATUS`_`FAILED
+
+noqa: F841
+
 <a id="cosmpy.aerial.faucet.FaucetApi.__init__"></a>
 
 #### `__`init`__`

--- a/docs/api/aerial/faucet.md
+++ b/docs/api/aerial/faucet.md
@@ -14,30 +14,6 @@ class FaucetApi()
 
 Faucet API.
 
-<a id="cosmpy.aerial.faucet.FaucetApi.FAUCET_STATUS_PENDING"></a>
-
-#### FAUCET`_`STATUS`_`PENDING
-
-noqa: F841
-
-<a id="cosmpy.aerial.faucet.FaucetApi.FAUCET_STATUS_PROCESSING"></a>
-
-#### FAUCET`_`STATUS`_`PROCESSING
-
-noqa: F841
-
-<a id="cosmpy.aerial.faucet.FaucetApi.FAUCET_STATUS_COMPLETED"></a>
-
-#### FAUCET`_`STATUS`_`COMPLETED
-
-noqa: F841
-
-<a id="cosmpy.aerial.faucet.FaucetApi.FAUCET_STATUS_FAILED"></a>
-
-#### FAUCET`_`STATUS`_`FAILED
-
-noqa: F841
-
 <a id="cosmpy.aerial.faucet.FaucetApi.__init__"></a>
 
 #### `__`init`__`

--- a/docs/api/aerial/gas.md
+++ b/docs/api/aerial/gas.md
@@ -113,6 +113,115 @@ Get the block gas limit.
 
 block gas limit
 
+<a id="cosmpy.aerial.gas.AsyncGasStrategy"></a>
+
+## AsyncGasStrategy Objects
+
+```python
+class AsyncGasStrategy(ABC)
+```
+
+Transaction gas strategy for the async ledger client.
+
+<a id="cosmpy.aerial.gas.AsyncGasStrategy.estimate_gas"></a>
+
+#### estimate`_`gas
+
+```python
+@abstractmethod
+async def estimate_gas(tx: Transaction) -> int
+```
+
+Estimate the transaction gas.
+
+**Arguments**:
+
+- `tx`: Transaction
+
+**Returns**:
+
+None
+
+<a id="cosmpy.aerial.gas.AsyncGasStrategy.block_gas_limit"></a>
+
+#### block`_`gas`_`limit
+
+```python
+@abstractmethod
+async def block_gas_limit() -> int
+```
+
+Get the block gas limit.
+
+**Returns**:
+
+None
+
+<a id="cosmpy.aerial.gas.AsyncSimulationGasStrategy"></a>
+
+## AsyncSimulationGasStrategy Objects
+
+```python
+class AsyncSimulationGasStrategy(AsyncGasStrategy)
+```
+
+Simulation transaction gas strategy for the async ledger client.
+
+**Arguments**:
+
+- `AsyncGasStrategy`: async gas strategy
+
+<a id="cosmpy.aerial.gas.AsyncSimulationGasStrategy.__init__"></a>
+
+#### `__`init`__`
+
+```python
+def __init__(client: "AsyncLedgerClient", multiplier: Optional[float] = None)
+```
+
+Init the Simulation transaction gas strategy.
+
+**Arguments**:
+
+- `client`: Async ledger client
+- `multiplier`: multiplier, defaults to None
+
+<a id="cosmpy.aerial.gas.AsyncSimulationGasStrategy.estimate_gas"></a>
+
+#### estimate`_`gas
+
+```python
+async def estimate_gas(tx: Transaction) -> int
+```
+
+Get estimated transaction gas.
+
+**Arguments**:
+
+- `tx`: transaction
+
+**Returns**:
+
+Estimated transaction gas
+
+<a id="cosmpy.aerial.gas.AsyncSimulationGasStrategy.block_gas_limit"></a>
+
+#### block`_`gas`_`limit
+
+```python
+async def block_gas_limit() -> int
+```
+
+Get the block gas limit.
+
+**Raises**:
+
+- `Exception`: Failed to query max_gas
+
+**Returns**:
+
+block gas limit
+
 <a id="cosmpy.aerial.gas.OfflineMessageTableStrategy"></a>
 
 ## OfflineMessageTableStrategy Objects

--- a/docs/api/aerial/tx_helpers.md
+++ b/docs/api/aerial/tx_helpers.md
@@ -15,18 +15,6 @@ class MessageLog()
 
 Message Log.
 
-<a id="cosmpy.aerial.tx_helpers.MessageLog.index"></a>
-
-#### index
-
-noqa
-
-<a id="cosmpy.aerial.tx_helpers.MessageLog.log"></a>
-
-#### log
-
-noqa
-
 <a id="cosmpy.aerial.tx_helpers.TxResponse"></a>
 
 ## TxResponse Objects

--- a/docs/api/aerial/tx_helpers.md
+++ b/docs/api/aerial/tx_helpers.md
@@ -15,6 +15,18 @@ class MessageLog()
 
 Message Log.
 
+<a id="cosmpy.aerial.tx_helpers.MessageLog.index"></a>
+
+#### index
+
+noqa
+
+<a id="cosmpy.aerial.tx_helpers.MessageLog.log"></a>
+
+#### log
+
+noqa
+
 <a id="cosmpy.aerial.tx_helpers.TxResponse"></a>
 
 ## TxResponse Objects
@@ -156,6 +168,38 @@ def wait_to_complete(
     timeout: Optional[Union[int, float, timedelta]] = None,
     poll_period: Optional[Union[int, float,
                                 timedelta]] = None) -> "SubmittedTx"
+```
+
+Wait to complete the transaction.
+
+**Arguments**:
+
+- `timeout`: timeout, defaults to None
+- `poll_period`: poll_period, defaults to None
+
+**Returns**:
+
+Submitted Transaction
+
+<a id="cosmpy.aerial.tx_helpers.AsyncSubmittedTx"></a>
+
+## AsyncSubmittedTx Objects
+
+```python
+class AsyncSubmittedTx(SubmittedTx)
+```
+
+Submitted transaction bound to an AsyncLedgerClient.
+
+<a id="cosmpy.aerial.tx_helpers.AsyncSubmittedTx.wait_to_complete"></a>
+
+#### wait`_`to`_`complete
+
+```python
+async def wait_to_complete(
+    timeout: Optional[Union[int, float, timedelta]] = None,
+    poll_period: Optional[Union[int, float, timedelta]] = None
+) -> "AsyncSubmittedTx"
 ```
 
 Wait to complete the transaction.

--- a/poetry.lock
+++ b/poetry.lock
@@ -35,23 +35,18 @@ trio = ["trio (>=0.31.0)"]
 
 [[package]]
 name = "astroid"
-version = "2.13.5"
+version = "3.3.11"
 description = "An abstract syntax tree for Python with inference support."
 optional = false
-python-versions = ">=3.7.2"
+python-versions = ">=3.9.0"
 groups = ["dev"]
 files = [
-    {file = "astroid-2.13.5-py3-none-any.whl", hash = "sha256:6891f444625b6edb2ac798829b689e95297e100ddf89dbed5a8c610e34901501"},
-    {file = "astroid-2.13.5.tar.gz", hash = "sha256:df164d5ac811b9f44105a72b8f9d5edfb7b5b2d7e979b04ea377a77b3229114a"},
+    {file = "astroid-3.3.11-py3-none-any.whl", hash = "sha256:54c760ae8322ece1abd213057c4b5bba7c49818853fc901ef09719a60dbf9dec"},
+    {file = "astroid-3.3.11.tar.gz", hash = "sha256:1e5a5011af2920c7c67a53f65d536d65bfa7116feeaf2354d8b94f29573bb0ce"},
 ]
 
 [package.dependencies]
-lazy-object-proxy = ">=1.4.0"
-typing-extensions = {version = ">=4.0.0", markers = "python_version < \"3.11\""}
-wrapt = [
-    {version = ">=1.11,<2", markers = "python_version < \"3.11\""},
-    {version = ">=1.14,<2", markers = "python_version >= \"3.11\""},
-]
+typing-extensions = {version = ">=4", markers = "python_version < \"3.11\""}
 
 [[package]]
 name = "attrs"
@@ -1416,53 +1411,6 @@ files = [
 referencing = ">=0.31.0"
 
 [[package]]
-name = "lazy-object-proxy"
-version = "1.10.0"
-description = "A fast and thorough lazy object proxy."
-optional = false
-python-versions = ">=3.8"
-groups = ["dev"]
-files = [
-    {file = "lazy-object-proxy-1.10.0.tar.gz", hash = "sha256:78247b6d45f43a52ef35c25b5581459e85117225408a4128a3daf8bf9648ac69"},
-    {file = "lazy_object_proxy-1.10.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:855e068b0358ab916454464a884779c7ffa312b8925c6f7401e952dcf3b89977"},
-    {file = "lazy_object_proxy-1.10.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7ab7004cf2e59f7c2e4345604a3e6ea0d92ac44e1c2375527d56492014e690c3"},
-    {file = "lazy_object_proxy-1.10.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc0d2fc424e54c70c4bc06787e4072c4f3b1aa2f897dfdc34ce1013cf3ceef05"},
-    {file = "lazy_object_proxy-1.10.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:e2adb09778797da09d2b5ebdbceebf7dd32e2c96f79da9052b2e87b6ea495895"},
-    {file = "lazy_object_proxy-1.10.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:b1f711e2c6dcd4edd372cf5dec5c5a30d23bba06ee012093267b3376c079ec83"},
-    {file = "lazy_object_proxy-1.10.0-cp310-cp310-win32.whl", hash = "sha256:76a095cfe6045c7d0ca77db9934e8f7b71b14645f0094ffcd842349ada5c5fb9"},
-    {file = "lazy_object_proxy-1.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:b4f87d4ed9064b2628da63830986c3d2dca7501e6018347798313fcf028e2fd4"},
-    {file = "lazy_object_proxy-1.10.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:fec03caabbc6b59ea4a638bee5fce7117be8e99a4103d9d5ad77f15d6f81020c"},
-    {file = "lazy_object_proxy-1.10.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:02c83f957782cbbe8136bee26416686a6ae998c7b6191711a04da776dc9e47d4"},
-    {file = "lazy_object_proxy-1.10.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:009e6bb1f1935a62889ddc8541514b6a9e1fcf302667dcb049a0be5c8f613e56"},
-    {file = "lazy_object_proxy-1.10.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:75fc59fc450050b1b3c203c35020bc41bd2695ed692a392924c6ce180c6f1dc9"},
-    {file = "lazy_object_proxy-1.10.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:782e2c9b2aab1708ffb07d4bf377d12901d7a1d99e5e410d648d892f8967ab1f"},
-    {file = "lazy_object_proxy-1.10.0-cp311-cp311-win32.whl", hash = "sha256:edb45bb8278574710e68a6b021599a10ce730d156e5b254941754a9cc0b17d03"},
-    {file = "lazy_object_proxy-1.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:e271058822765ad5e3bca7f05f2ace0de58a3f4e62045a8c90a0dfd2f8ad8cc6"},
-    {file = "lazy_object_proxy-1.10.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:e98c8af98d5707dcdecc9ab0863c0ea6e88545d42ca7c3feffb6b4d1e370c7ba"},
-    {file = "lazy_object_proxy-1.10.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:952c81d415b9b80ea261d2372d2a4a2332a3890c2b83e0535f263ddfe43f0d43"},
-    {file = "lazy_object_proxy-1.10.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80b39d3a151309efc8cc48675918891b865bdf742a8616a337cb0090791a0de9"},
-    {file = "lazy_object_proxy-1.10.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:e221060b701e2aa2ea991542900dd13907a5c90fa80e199dbf5a03359019e7a3"},
-    {file = "lazy_object_proxy-1.10.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:92f09ff65ecff3108e56526f9e2481b8116c0b9e1425325e13245abfd79bdb1b"},
-    {file = "lazy_object_proxy-1.10.0-cp312-cp312-win32.whl", hash = "sha256:3ad54b9ddbe20ae9f7c1b29e52f123120772b06dbb18ec6be9101369d63a4074"},
-    {file = "lazy_object_proxy-1.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:127a789c75151db6af398b8972178afe6bda7d6f68730c057fbbc2e96b08d282"},
-    {file = "lazy_object_proxy-1.10.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:9e4ed0518a14dd26092614412936920ad081a424bdcb54cc13349a8e2c6d106a"},
-    {file = "lazy_object_proxy-1.10.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5ad9e6ed739285919aa9661a5bbed0aaf410aa60231373c5579c6b4801bd883c"},
-    {file = "lazy_object_proxy-1.10.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2fc0a92c02fa1ca1e84fc60fa258458e5bf89d90a1ddaeb8ed9cc3147f417255"},
-    {file = "lazy_object_proxy-1.10.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:0aefc7591920bbd360d57ea03c995cebc204b424524a5bd78406f6e1b8b2a5d8"},
-    {file = "lazy_object_proxy-1.10.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:5faf03a7d8942bb4476e3b62fd0f4cf94eaf4618e304a19865abf89a35c0bbee"},
-    {file = "lazy_object_proxy-1.10.0-cp38-cp38-win32.whl", hash = "sha256:e333e2324307a7b5d86adfa835bb500ee70bfcd1447384a822e96495796b0ca4"},
-    {file = "lazy_object_proxy-1.10.0-cp38-cp38-win_amd64.whl", hash = "sha256:cb73507defd385b7705c599a94474b1d5222a508e502553ef94114a143ec6696"},
-    {file = "lazy_object_proxy-1.10.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:366c32fe5355ef5fc8a232c5436f4cc66e9d3e8967c01fb2e6302fd6627e3d94"},
-    {file = "lazy_object_proxy-1.10.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2297f08f08a2bb0d32a4265e98a006643cd7233fb7983032bd61ac7a02956b3b"},
-    {file = "lazy_object_proxy-1.10.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:18dd842b49456aaa9a7cf535b04ca4571a302ff72ed8740d06b5adcd41fe0757"},
-    {file = "lazy_object_proxy-1.10.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:217138197c170a2a74ca0e05bddcd5f1796c735c37d0eee33e43259b192aa424"},
-    {file = "lazy_object_proxy-1.10.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:9a3a87cf1e133e5b1994144c12ca4aa3d9698517fe1e2ca82977781b16955658"},
-    {file = "lazy_object_proxy-1.10.0-cp39-cp39-win32.whl", hash = "sha256:30b339b2a743c5288405aa79a69e706a06e02958eab31859f7f3c04980853b70"},
-    {file = "lazy_object_proxy-1.10.0-cp39-cp39-win_amd64.whl", hash = "sha256:a899b10e17743683b293a729d3a11f2f399e8a90c73b089e29f5d0fe3509f0dd"},
-    {file = "lazy_object_proxy-1.10.0-pp310.pp311.pp312.pp38.pp39-none-any.whl", hash = "sha256:80fa48bd89c8f2f456fc0765c11c23bf5af827febacd2f523ca5bc1893fcc09d"},
-]
-
-[[package]]
 name = "liccheck"
 version = "0.9.2"
 description = "Check python packages from requirement.txt and report issues"
@@ -2260,24 +2208,28 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pylint"
-version = "2.15.5"
+version = "3.3.9"
 description = "python code static checker"
 optional = false
-python-versions = ">=3.7.2"
+python-versions = ">=3.9.0"
 groups = ["dev"]
 files = [
-    {file = "pylint-2.15.5-py3-none-any.whl", hash = "sha256:c2108037eb074334d9e874dc3c783752cc03d0796c88c9a9af282d0f161a1004"},
-    {file = "pylint-2.15.5.tar.gz", hash = "sha256:3b120505e5af1d06a5ad76b55d8660d44bf0f2fc3c59c2bdd94e39188ee3a4df"},
+    {file = "pylint-3.3.9-py3-none-any.whl", hash = "sha256:01f9b0462c7730f94786c283f3e52a1fbdf0494bbe0971a78d7277ef46a751e7"},
+    {file = "pylint-3.3.9.tar.gz", hash = "sha256:d312737d7b25ccf6b01cc4ac629b5dcd14a0fcf3ec392735ac70f137a9d5f83a"},
 ]
 
 [package.dependencies]
-astroid = ">=2.12.12,<=2.14.0-dev0"
+astroid = ">=3.3.8,<=3.4.0.dev0"
 colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
-dill = ">=0.2"
-isort = ">=4.2.5,<6"
+dill = [
+    {version = ">=0.2", markers = "python_version < \"3.11\""},
+    {version = ">=0.3.7", markers = "python_version >= \"3.12\""},
+    {version = ">=0.3.6", markers = "python_version == \"3.11\""},
+]
+isort = ">=4.2.5,<5.13 || >5.13,<7"
 mccabe = ">=0.6,<0.8"
-platformdirs = ">=2.2.0"
-tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
+platformdirs = ">=2.2"
+tomli = {version = ">=1.1", markers = "python_version < \"3.11\""}
 tomlkit = ">=0.10.1"
 
 [package.extras]
@@ -2767,7 +2719,7 @@ description = "C version of reader, parser and emitter for ruamel.yaml derived f
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
-markers = "platform_python_implementation == \"CPython\" and python_version < \"3.13\""
+markers = "python_version <= \"3.12\" and platform_python_implementation == \"CPython\""
 files = [
     {file = "ruamel.yaml.clib-0.2.12-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:11f891336688faf5156a36293a9c362bdc7c88f03a8a027c2c1d8e0bcde998e5"},
     {file = "ruamel.yaml.clib-0.2.12-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:a606ef75a60ecf3d924613892cc603b154178ee25abb3055db5062da811fd969"},
@@ -3187,7 +3139,7 @@ files = [
     {file = "typing_extensions-4.13.2-py3-none-any.whl", hash = "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c"},
     {file = "typing_extensions-4.13.2.tar.gz", hash = "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef"},
 ]
-markers = {main = "python_version < \"3.13\""}
+markers = {main = "python_version <= \"3.12\""}
 
 [[package]]
 name = "urllib3"
@@ -3293,7 +3245,7 @@ version = "1.17.2"
 description = "Module for decorators, wrappers and monkey patching."
 optional = false
 python-versions = ">=3.8"
-groups = ["dev", "docs"]
+groups = ["docs"]
 files = [
     {file = "wrapt-1.17.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3d57c572081fed831ad2d26fd430d565b76aa277ed1d30ff4d40670b1c0dd984"},
     {file = "wrapt-1.17.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b5e251054542ae57ac7f3fba5d10bfff615b6c2fb09abeb37d2f1463f841ae22"},
@@ -3416,4 +3368,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "1201b319b6590da51c220f34a25f47ed4f0be82953c736e1038f0a7f836bfce1"
+content-hash = "bcd31779fc34d46e1f541df858e4123cb1ba3c1bcb1cf5a15c1fe0dd5073df87"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ safety = "==3.6.1"
 isort = "==5.10.1"
 darglint = "==1.8.1"
 vulture = "==2.6"
-pylint = "==2.15.5"
+pylint = "==3.3.9"
 flake8-copyright = "==0.2.3"
 grpcio-tools = ">=1.66.2"
 flake8-bugbear = "==22.10.25"
@@ -175,6 +175,8 @@ max-statements = 80
 max-parents = 11
 max-branches = 24
 max-attributes = 38
+# R0917: match max-args; gRPC-style methods legitimately take many positional params
+max-positional-arguments = 27
 
 [tool.pylint.refactoring]
 max-nested-blocks = 6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ pytest = "*"
 pytest-rerunfailures = "*"
 
 [tool.mypy]
-python_version = 3.10
+python_version = "3.10"
 strict_optional = true
 exclude = "whitelist.py"
 
@@ -127,7 +127,9 @@ module = [
     "dateutil.*",
     "sortedcontainers.*",
     "bcrypt.*",
-    "nacl.*"
+    "nacl.*",
+    "tomli.*",
+    "Crypto.*"
 ]
 ignore_missing_imports = true
 

--- a/scripts/do-release.py
+++ b/scripts/do-release.py
@@ -26,7 +26,12 @@ import sys
 from pathlib import Path
 from typing import Dict, List, Tuple
 
-import tomli
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python < 3.11
+    import tomli as tomllib
+
 from packaging.version import Version
 
 
@@ -69,7 +74,7 @@ class ReleaseTool:
     def get_current_version(self) -> Version:
         """Get current code version."""
         text = (ROOT / "pyproject.toml").read_text()
-        version = tomli.loads(text)["tool"]["poetry"]["version"]
+        version = tomllib.loads(text)["tool"]["poetry"]["version"]
         return Version(version)
 
     def do_we_need_to_release(self) -> bool:

--- a/scripts/do-release.py
+++ b/scripts/do-release.py
@@ -26,13 +26,13 @@ import sys
 from pathlib import Path
 from typing import Dict, List, Tuple
 
-
-try:
-    import tomllib
-except ModuleNotFoundError:  # Python < 3.11
-    import tomli as tomllib
-
 from packaging.version import Version
+
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 
 ROOT = Path(__file__).parent.parent

--- a/scripts/whitelist.py
+++ b/scripts/whitelist.py
@@ -88,3 +88,6 @@ _.ensure_funds  # unused method (./clients/ledger.py:656)
 _.staking_denomination
 _.fetch_mainnet
 _.is_successful
+exc_type  # unused variable (./aerial/client/aio.py: AsyncLedgerClient.__aexit__)
+exc_value  # unused variable (./aerial/client/aio.py: AsyncLedgerClient.__aexit__)
+traceback  # unused variable (./aerial/client/aio.py: AsyncLedgerClient.__aexit__)

--- a/tests/unit/test_aerial/test_async_client.py
+++ b/tests/unit/test_aerial/test_async_client.py
@@ -122,9 +122,12 @@ def test_async_query_account():
     packed_account.Pack(account)
 
     class MockAuthStub:  # pylint: disable=too-few-public-methods
+        """Mock async auth stub."""
+
         async def Account(
             self, request
         ):  # noqa: N802 # pylint: disable=invalid-name,unused-argument
+            """Return a fixed account query response."""
             return QueryAccountResponse(account=packed_account)
 
     async def check(client):
@@ -141,7 +144,10 @@ def test_async_query_bank_balance():
     """Test querying a bank balance over a mocked async bank stub."""
 
     class MockBankStub:  # pylint: disable=too-few-public-methods
+        """Mock async bank stub."""
+
         async def Balance(self, request):  # noqa: N802 # pylint: disable=invalid-name
+            """Return a fixed balance for the requested denom."""
             return QueryBalanceResponse(
                 balance=PbCoin(denom=request.denom, amount="1234")
             )
@@ -157,9 +163,12 @@ def test_async_query_tx_not_found_and_wait_timeout():
     """Test tx not found translation and wait_for_query_tx timeout."""
 
     class MockTxStub:  # pylint: disable=too-few-public-methods
+        """Mock async tx stub whose GetTx always fails with 'tx not found'."""
+
         async def GetTx(
             self, request
         ):  # noqa: N802 # pylint: disable=invalid-name,unused-argument
+            """Raise a 'tx not found' error."""
             raise RuntimeError("tx not found")
 
     async def check_not_found(client):
@@ -182,14 +191,18 @@ def test_async_broadcast_and_wait():
     tx_hash = "ABCDEF0123456789"
 
     class MockTxStub:  # pylint: disable=too-few-public-methods
+        """Mock async tx stub for broadcast and completion polling."""
+
         async def BroadcastTx(
             self, request
         ):  # noqa: N802 # pylint: disable=invalid-name,unused-argument
+            """Return a successful broadcast response."""
             return BroadcastTxResponse(tx_response=PbTxResponse(txhash=tx_hash, code=0))
 
         async def GetTx(
             self, request
         ):  # noqa: N802 # pylint: disable=invalid-name,unused-argument
+            """Return a completed tx response."""
             return GetTxResponse(
                 tx_response=PbTxResponse(txhash=tx_hash, code=0, height=42)
             )
@@ -212,15 +225,21 @@ def test_async_gas_estimation_with_simulation_strategy():
     """Test the async simulation gas strategy end to end over mocked stubs."""
 
     class MockTxStub:  # pylint: disable=too-few-public-methods
+        """Mock async tx stub for gas simulation."""
+
         async def Simulate(
             self, request
         ):  # noqa: N802 # pylint: disable=invalid-name,unused-argument
+            """Return a fixed gas-used simulation response."""
             return SimulateResponse(gas_info=GasInfo(gas_used=100_000))
 
     class MockConsensusStub:  # pylint: disable=too-few-public-methods
+        """Mock async consensus stub."""
+
         async def Params(
             self, request
         ):  # noqa: N802 # pylint: disable=invalid-name,unused-argument
+            """Return consensus params with a fixed block max_gas."""
             return SimpleNamespace(
                 params=SimpleNamespace(block=SimpleNamespace(max_gas=3_000_000))
             )

--- a/tests/unit/test_aerial/test_async_client.py
+++ b/tests/unit/test_aerial/test_async_client.py
@@ -1,0 +1,261 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2018-2022 Fetch.AI Limited
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+
+"""Test aerial async ledger client."""
+
+
+import asyncio
+from dataclasses import replace
+from types import SimpleNamespace
+
+import pytest
+from google.protobuf.any_pb2 import Any as ProtoAny
+
+from cosmpy.aerial.client import (
+    DEFAULT_QUERY_INTERVAL_SECS,
+    DEFAULT_QUERY_TIMEOUT_SECS,
+    LedgerClient,
+)
+from cosmpy.aerial.client.aio import AsyncLedgerClient
+from cosmpy.aerial.config import NetworkConfig
+from cosmpy.aerial.exceptions import NotFoundError, QueryTimeoutError
+from cosmpy.aerial.gas import AsyncSimulationGasStrategy, OfflineMessageTableStrategy
+from cosmpy.aerial.tx_helpers import AsyncSubmittedTx
+from cosmpy.crypto.address import Address
+from cosmpy.protos.cosmos.auth.v1beta1.auth_pb2 import BaseAccount
+from cosmpy.protos.cosmos.auth.v1beta1.query_pb2 import QueryAccountResponse
+from cosmpy.protos.cosmos.bank.v1beta1.query_pb2 import QueryBalanceResponse
+from cosmpy.protos.cosmos.base.abci.v1beta1.abci_pb2 import GasInfo
+from cosmpy.protos.cosmos.base.abci.v1beta1.abci_pb2 import TxResponse as PbTxResponse
+from cosmpy.protos.cosmos.base.v1beta1.coin_pb2 import Coin as PbCoin
+from cosmpy.protos.cosmos.tx.v1beta1.service_pb2 import (
+    BroadcastTxResponse,
+    GetTxResponse,
+    SimulateResponse,
+)
+
+
+TEST_ADDRESS = Address("fetch12hyw0z8za0sc9wwfhkdz2qrc89a87z42py23vn")
+
+
+def run_with_client(coro_fn, **client_kwargs):
+    """Run coro_fn(client) inside a fresh event loop.
+
+    The grpc.aio channel must be created from within a running event loop, so the
+    client is constructed inside the loop, mirroring real-world usage with
+    ``asyncio.run(main())``.
+
+    :param coro_fn: async callable taking the client as its only argument
+    :param client_kwargs: extra kwargs for the AsyncLedgerClient constructor
+    :return: result of coro_fn
+    """
+
+    async def main():
+        async with AsyncLedgerClient(
+            NetworkConfig.fetchai_stable_testnet(), **client_kwargs
+        ) as client:
+            return await coro_fn(client)
+
+    return asyncio.run(main())
+
+
+def test_async_ledger_client_timeouts():
+    """Test async ledger client query_interval_secs and query_timeout_secs options."""
+
+    async def check_defaults(client):
+        assert (
+            client._query_interval_secs  # pylint: disable=protected-access
+            == DEFAULT_QUERY_INTERVAL_SECS
+        )
+        assert (
+            client._query_timeout_secs  # pylint: disable=protected-access
+            == DEFAULT_QUERY_TIMEOUT_SECS
+        )
+
+    run_with_client(check_defaults)
+
+    timeout = 100
+    interval = 5000
+
+    async def check_custom(client):
+        assert (
+            client._query_interval_secs == interval  # pylint: disable=protected-access
+        )
+        assert client._query_timeout_secs == timeout  # pylint: disable=protected-access
+
+    run_with_client(
+        check_custom, query_interval_secs=interval, query_timeout_secs=timeout
+    )
+
+
+def test_async_ledger_client_rejects_rest_endpoints():
+    """Test async ledger client raises on REST network configurations."""
+    cfg = replace(
+        NetworkConfig.fetchai_stable_testnet(),
+        url="rest+https://rest-fetchhub.fetch.ai",
+    )
+    with pytest.raises(RuntimeError, match="gRPC endpoints only"):
+        AsyncLedgerClient(cfg)
+
+
+def test_async_query_account():
+    """Test querying an account over a mocked async auth stub."""
+    account = BaseAccount(address=str(TEST_ADDRESS), account_number=5, sequence=7)
+    packed_account = ProtoAny()
+    packed_account.Pack(account)
+
+    class MockAuthStub:  # pylint: disable=too-few-public-methods
+        async def Account(
+            self, request
+        ):  # noqa: N802 # pylint: disable=invalid-name,unused-argument
+            return QueryAccountResponse(account=packed_account)
+
+    async def check(client):
+        client.auth = MockAuthStub()
+        return await client.query_account(TEST_ADDRESS)
+
+    result = run_with_client(check)
+    assert result.address == TEST_ADDRESS
+    assert result.number == 5
+    assert result.sequence == 7
+
+
+def test_async_query_bank_balance():
+    """Test querying a bank balance over a mocked async bank stub."""
+
+    class MockBankStub:  # pylint: disable=too-few-public-methods
+        async def Balance(self, request):  # noqa: N802 # pylint: disable=invalid-name
+            return QueryBalanceResponse(
+                balance=PbCoin(denom=request.denom, amount="1234")
+            )
+
+    async def check(client):
+        client.bank = MockBankStub()
+        return await client.query_bank_balance(TEST_ADDRESS)
+
+    assert run_with_client(check) == 1234
+
+
+def test_async_query_tx_not_found_and_wait_timeout():
+    """Test tx not found translation and wait_for_query_tx timeout."""
+
+    class MockTxStub:  # pylint: disable=too-few-public-methods
+        async def GetTx(
+            self, request
+        ):  # noqa: N802 # pylint: disable=invalid-name,unused-argument
+            raise RuntimeError("tx not found")
+
+    async def check_not_found(client):
+        client.txs = MockTxStub()
+        await client.query_tx("DEADBEEF")
+
+    with pytest.raises(NotFoundError):
+        run_with_client(check_not_found)
+
+    async def check_timeout(client):
+        client.txs = MockTxStub()
+        await client.wait_for_query_tx("DEADBEEF", timeout=0.2, poll_period=0.05)
+
+    with pytest.raises(QueryTimeoutError):
+        run_with_client(check_timeout)
+
+
+def test_async_broadcast_and_wait():
+    """Test broadcasting a transaction and waiting for its completion."""
+    tx_hash = "ABCDEF0123456789"
+
+    class MockTxStub:  # pylint: disable=too-few-public-methods
+        async def BroadcastTx(
+            self, request
+        ):  # noqa: N802 # pylint: disable=invalid-name,unused-argument
+            return BroadcastTxResponse(tx_response=PbTxResponse(txhash=tx_hash, code=0))
+
+        async def GetTx(
+            self, request
+        ):  # noqa: N802 # pylint: disable=invalid-name,unused-argument
+            return GetTxResponse(
+                tx_response=PbTxResponse(txhash=tx_hash, code=0, height=42)
+            )
+
+    tx = SimpleNamespace(tx=SimpleNamespace(SerializeToString=lambda: b""))
+
+    async def check(client):
+        client.txs = MockTxStub()
+        submitted = await client.broadcast_tx(tx)
+        assert isinstance(submitted, AsyncSubmittedTx)
+        assert submitted.tx_hash == tx_hash
+        return await submitted.wait_to_complete(timeout=1, poll_period=0.05)
+
+    submitted = run_with_client(check)
+    assert submitted.response is not None
+    assert submitted.response.height == 42
+
+
+def test_async_gas_estimation_with_simulation_strategy():
+    """Test the async simulation gas strategy end to end over mocked stubs."""
+
+    class MockTxStub:  # pylint: disable=too-few-public-methods
+        async def Simulate(
+            self, request
+        ):  # noqa: N802 # pylint: disable=invalid-name,unused-argument
+            return SimulateResponse(gas_info=GasInfo(gas_used=100_000))
+
+    class MockConsensusStub:  # pylint: disable=too-few-public-methods
+        async def Params(
+            self, request
+        ):  # noqa: N802 # pylint: disable=invalid-name,unused-argument
+            return SimpleNamespace(
+                params=SimpleNamespace(block=SimpleNamespace(max_gas=3_000_000))
+            )
+
+    tx = SimpleNamespace(state="unused", tx=None)
+
+    async def check(client):
+        client.txs = MockTxStub()
+        client.consensus = MockConsensusStub()
+        assert isinstance(client.gas_strategy, AsyncSimulationGasStrategy)
+        # bypass the final-state check by using a transaction-like object
+        client._check_tx_final_for_simulation = (  # pylint: disable=protected-access
+            lambda _tx: None
+        )
+        return await client.estimate_gas_and_fee_for_tx(tx)
+
+    gas, fee = run_with_client(check)
+    assert gas == int(100_000 * AsyncSimulationGasStrategy.DEFAULT_MULTIPLIER)
+    assert fee.endswith(NetworkConfig.fetchai_stable_testnet().fee_denomination)
+
+
+def test_async_client_accepts_sync_offline_gas_strategy():
+    """Test that an I/O-free sync gas strategy can be used by the async client."""
+    tx = SimpleNamespace(msgs=[])
+
+    async def check(client):
+        client.gas_strategy = OfflineMessageTableStrategy.default_table()
+        return await client.estimate_gas_for_tx(tx)
+
+    assert run_with_client(check) == 0
+
+
+def test_sync_and_async_clients_share_parsing():
+    """Test both clients share the same tx-response parsing implementation."""
+    assert (
+        LedgerClient._parse_tx_response  # pylint: disable=protected-access
+        is AsyncLedgerClient._parse_tx_response  # pylint: disable=protected-access
+    )


### PR DESCRIPTION
Extract the I/O-free logic of LedgerClient (parsers, fee math, stub wiring, poll timings) into a shared LedgerClientBase and add AsyncLedgerClient, which runs the same generated protobuf stubs over a grpc.aio channel. The sync client is a pure refactor - no API or behavior changes.

- cosmpy/aerial/client/base.py: shared I/O-free base for both clients
- cosmpy/aerial/client/aio.py: AsyncLedgerClient + async tx helpers (prepare_and_broadcast_basic_transaction, simulate_tx, get_paginated); gRPC endpoints only, REST URLs raise with a clear message
- gas.py: AsyncGasStrategy and AsyncSimulationGasStrategy; async client also accepts I/O-free sync strategies (e.g. OfflineMessageTableStrategy)
- tx_helpers.py: AsyncSubmittedTx with awaitable wait_to_complete()
- tests: async client unit tests over mocked aio stubs

## Proposed Changes

_[describe the changes here...]_

## Linked Issues

_[if applicable, add links to issues resolved by this PR]_

## Types of changes

_What type of change does this pull request make (put an `x` in the boxes that apply)?_

- [ ] Bug fix (non-breaking change that fixes an issue).
- [ ] New feature added (non-breaking change that adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to stop working as expected).
- [ ] Documentation update.
- [ ] Something else (e.g., tests, scripts, example, deployment, infrastructure).

## Checklist

_Put an `x` in the boxes that apply:_

- [ ] I have read the [CONTRIBUTING](https://github.com/fetchai/cosmpy/blob/main/CONTRIBUTING.md) guide
- [ ] Checks and tests pass locally

### If applicable

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease
- [ ] I have added/updated the documentation

## Further comments

_[if this is a relatively large or complex change, kick off a discussion by explaining why you chose the solution you did, what alternatives you considered, etc...]_
